### PR TITLE
Cookie consent

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -233,6 +233,17 @@ if (UserAccount::isLoggedIn() && UserAccount::userHasPermission('Submit Ticket')
 		//This happens before the table is setup
 	}
 }
+//Check to see if we should show the cookieConsent banner
+$interface->assign('cookieStorageConsent', false);
+try {
+	require_once ROOT_DIR . '/sys/SystemVariables.php';
+	$systemVariables = new SystemVariables();
+	if ($systemVariables->find(true) && !empty($systemVariables->cookieStorageConsent)) {
+		$interface->assign('cookieStorageConsent', true);
+	}
+} catch (Exception $e) {
+	AspenError::raiseError("Error loading cookie consent banner");
+}
 
 $deviceName = get_device_name();
 $interface->assign('deviceName', $deviceName);

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -240,6 +240,7 @@ try {
 	$systemVariables = new SystemVariables();
 	if ($systemVariables->find(true) && !empty($systemVariables->cookieStorageConsent)) {
 		$interface->assign('cookieStorageConsent', true);
+		$interface->assign('cookieStorageConsentHTML', $systemVariables->cookiePolicyHTML);
 	}
 } catch (Exception $e) {
 	AspenError::raiseError("Error loading cookie consent banner");

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,0 +1,17 @@
+{if !$smarty.cookies.cookieConsent}
+    <div class="stripPopup">
+        <div class="container">
+            <div class="contentWrap">
+                <span>We use cookies on this site to enhance your user experience.</span>
+                <abbr>By clicking any link on this website, you are giving us consent to set and store cookies.</abbr>
+            </div>
+            <div class="btnWrap">
+                <a href="#" id="consentAgree" class="button">Yes, I agree</a>
+                <a href="#" id="consentDisagree" class="button">No, I want to find out more</a>
+            </div>
+        </div>
+    </div>
+    <link rel="stylesheet" href="/interface/themes/responsive/css/cookie-consent.css" />
+    <script>cookiePolicyHTML='{$cookieStorageConsentHTML|escape:javascript|regex_replace:"/[\r\n]/" : " "}'</script>
+    <script src="/interface/themes/responsive/js/aspen/cookieConsent.js"></script>
+{/if}

--- a/code/web/interface/themes/responsive/css/cookie-consent.css
+++ b/code/web/interface/themes/responsive/css/cookie-consent.css
@@ -1,0 +1,104 @@
+@font-face {
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 200;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLFj_V1s.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiEyp8kv8JHgFVrFJA.ttf) format('truetype');
+}
+@font-face {
+  font-family: 'Poppins';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://fonts.gstatic.com/s/poppins/v20/pxiByp8kv8JHgFVrLCz7V1s.ttf) format('truetype');
+}
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+.stripPopup {
+  background-color: #1d7ff0;
+  padding: 15px 0;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+  font-family: 'Poppins', sans-serif;
+}
+.stripPopup .btnWrap {
+  width: 400px;
+  float: right;
+  display: flex;
+}
+.stripPopup .btnWrap a.button {
+  width: 188px;
+  color: white;
+  padding: 12px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: normal;
+  text-align: center;
+  border: 1px solid white;
+  margin: 2px 5px 0;
+  display: inline-block;
+  text-decoration: none;
+  transition: all 0.3s ease-in-out;
+  -webkit-transition: all 0.3s ease-in-out;
+  -moz-transition: all 0.3s ease-in-out;
+}
+.stripPopup .btnWrap a.button:hover {
+  background-color: red;
+  transition: all 0.3s ease-in-out;
+  -webkit-transition: all 0.3s ease-in-out;
+  -moz-transition: all 0.3s ease-in-out;
+}
+.stripPopup .container {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 1000px;
+  display: block;
+  padding: 0 20px;
+  margin: 0 auto;
+}
+.stripPopup .container .contentWrap {
+  width: 490px;
+  float: left;
+}
+.stripPopup .container .contentWrap span {
+  font-size: 14px;
+  color: #fff;
+  font-weight: 700;
+  display: block;
+}
+.stripPopup .container .contentWrap abbr {
+  font-size: 12px;
+  color: white;
+  font-weight: 400;
+  display: block;
+}
+@media only screen and (max-width: 768px) {
+  .stripPopup .contentWrap {
+    width: 100%;
+    text-align: center;
+    display: block;
+  }
+  .stripPopup .btnWrap {
+    width: 100%;
+    text-align: center;
+    display: block;
+  }
+  .stripPopup .btnWrap a.button {
+    width: auto;
+    font-size: 12px;
+  }
+}

--- a/code/web/interface/themes/responsive/css/cookie-consent.less
+++ b/code/web/interface/themes/responsive/css/cookie-consent.less
@@ -1,0 +1,96 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;400;700&display=swap');
+
+*{
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+.stripPopup{
+    background-color: rgb(29, 127, 240);
+    padding: 15px 0;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1;
+    font-family: 'Poppins', sans-serif;
+
+    .btnWrap{
+        width: 400px;
+        float: right;
+        display: flex;
+
+        a.button{
+            width:188px;
+            color: white;
+            padding: 12px 10px;
+            font-size: 12px;
+            font-weight: 700;
+            line-height: normal;
+            text-align: center;
+            border: 1px solid white;
+            margin: 2px 5px 0;
+            display: inline-block; 
+            text-decoration: none;
+            transition: all .3s ease-in-out;
+            -webkit-transition: all .3s ease-in-out;
+            -moz-transition: all .3s ease-in-out;
+           
+        }
+            a.button:hover{
+                background-color: red;
+                transition: all .3s ease-in-out;
+                -webkit-transition: all .3s ease-in-out;
+                -moz-transition: all .3s ease-in-out;
+            }
+    }
+
+    .container{
+        display:flex;
+        justify-content: space-between;
+        width:100%;
+        max-width: 1000px;
+        display: block;
+        padding: 0 20px;
+        margin: 0 auto;
+
+        .contentWrap{
+            width: 490px;
+            float: left;
+
+            span{
+                font-size: 14px;
+                color: #fff;
+                font-weight: 700;
+                display: block;
+            }
+            abbr {
+                font-size: 12px;
+                color: white;
+                font-weight: 400;
+                display: block;
+            }
+            
+        }
+    }
+
+    @media only screen and (max-width: 768px) {
+
+        .contentWrap{
+            width: 100%;
+            text-align: center;
+            display: block;
+        }
+
+        .btnWrap{
+            width: 100%;
+            text-align: center;
+            display: block;
+
+            a.button{
+                width: auto;
+                font-size: 12px;
+            }
+        } 
+    }
+}     

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -1,0 +1,14 @@
+$(document).ready(function () {
+    var aDate = new Date();
+    aDate.setMonth(aDate.getMonth() + 3);
+    $(document).on('click', '#consentAgree, #modalConsentAgree', function (event) {
+        event.preventDefault();
+        $('.stripPopup').hide();
+        $('.modal').modal('hide');
+        document.cookie = 'cookieConsent' + '=' +encodeURIComponent(aDate)+'; expires=' + aDate.toUTCString() + '; path=/';
+    });
+    $('#consentDisagree').click(function() {
+        $('.stripPopup').hide();
+        AspenDiscovery.showMessageWithButtons("Cookie Policy",cookiePolicyHTML,'<button class=\'tool btn btn-primary\' id=\'modalConsentAgree\' >Accept essential cookies</button>', true);
+    });
+});

--- a/code/web/interface/themes/responsive/layout.tpl
+++ b/code/web/interface/themes/responsive/layout.tpl
@@ -170,7 +170,9 @@
 	{if !empty($customJavascript)}
 		{$customJavascript}
 	{/if}
-	{include file = "cookie-consent.tpl"}
+	{if !empty($cookieStorageConsent)}
+		{include file = "cookie-consent.tpl"}
+	{/if}
 {/strip}
 </body>
 </html>

--- a/code/web/interface/themes/responsive/layout.tpl
+++ b/code/web/interface/themes/responsive/layout.tpl
@@ -170,6 +170,7 @@
 	{if !empty($customJavascript)}
 		{$customJavascript}
 	{/if}
+	{include file = "cookie-consent.tpl"}
 {/strip}
 </body>
 </html>

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -1,0 +1,5 @@
+<!-- PTFS - E-->
+## Data Protection Updates
+- Add cookie consent banner and accompanying system variables to enable/disable.
+- Add policy page html system variable to be displayed to end user from cookie consent banner when enabled.
+- Move IP tracking to new 'Data Protection' section in sytem variables.

--- a/code/web/sys/DBMaintenance/version_updates/23.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.07.00.php
@@ -176,6 +176,16 @@ function getUpdates23_07_00(): array {
 				"ALTER TABLE system_variables add column cookieStorageConsent TINYINT(1) DEFAULT 0"
 			],
 		], //enable/disable cookie consent banner
+		
+		'cookie_policy_html' => [
+			'title' => 'Cookie Policy HTML',
+			'description' => 'Allow admin to set HTML for cookie policy',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE system_variables ADD COLUMN cookiePolicyHTML TEXT",
+				"UPDATE system_variables set cookiePolicyHTML = 'This body has not yet set a cookie storage policy, please check back later.'",
+			],
+		],  //storage of HTML for cookie policy
 	];
 }
 

--- a/code/web/sys/DBMaintenance/version_updates/23.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.07.00.php
@@ -168,6 +168,14 @@ function getUpdates23_07_00(): array {
 				'updateNotificationOnboardStatus',
 			],
 		], //update_notification_onboarding_status
+		//jacob
+		'cookie_storage_consent' => [
+			'title' => 'Track consent for storage of Cookies',
+			'description' => 'Enable/disable Cookie consent banner for GDPR compliance',
+			'sql' => [
+				"ALTER TABLE system_variables add column cookieStorageConsent TINYINT(1) DEFAULT 0"
+			],
+		], //enable/disable cookie consent banner
 	];
 }
 

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -31,6 +31,7 @@ class SystemVariables extends DataObject {
 	public $trackIpAddresses;
 	public $allowScheduledUpdates;
 	public $doQuickUpdates;
+	public $cookieStorageConsent;
 
 	static function getObjectStructure($context = ''): array {
 		return [
@@ -277,6 +278,13 @@ class SystemVariables extends DataObject {
 				'type' => 'checkbox',
 				'label' => 'Track IP Addresses',
 				'description' => 'Determine if IP Addresses should be tracked for each page view',
+				'default' => false,
+			],
+			'cookieStorageConsent' => [
+				'property' => 'cookieStorageConsent',
+				'type' => 'checkbox',
+				'label' => 'Require Cookie Storage Consent',
+				'description' => 'Require users to consent to cookie storage before using the catalog',
 				'default' => false,
 			],
 		];

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -32,6 +32,7 @@ class SystemVariables extends DataObject {
 	public $allowScheduledUpdates;
 	public $doQuickUpdates;
 	public $cookieStorageConsent;
+	public $cookiePolicyHTML;
 
 	static function getObjectStructure($context = ''): array {
 		return [
@@ -273,19 +274,36 @@ class SystemVariables extends DataObject {
 				'label' => 'App Scheme',
 				'description' => 'Scheme used for creating deep links into the app',
 			],
-			'trackIpAddresses' => [
-				'property' => 'trackIpAddresses',
-				'type' => 'checkbox',
-				'label' => 'Track IP Addresses',
-				'description' => 'Determine if IP Addresses should be tracked for each page view',
-				'default' => false,
-			],
-			'cookieStorageConsent' => [
-				'property' => 'cookieStorageConsent',
-				'type' => 'checkbox',
-				'label' => 'Require Cookie Storage Consent',
-				'description' => 'Require users to consent to cookie storage before using the catalog',
-				'default' => false,
+			'dataProtectionRegulations' => [
+				'property' => 'dataProtectionRegulations',
+				'type' => 'section',
+				'label' => 'Data Protection Regulations',
+				'hideInLists' => true,
+				'expandByDefault' => true,
+				'properties' => [
+					'cookieStorageConsent' => [
+						'property' => 'cookieStorageConsent',
+						'type' => 'checkbox',
+						'label' => 'Require Cookie Storage Consent',
+						'description' => 'Require users to consent to cookie storage before using the catalog',
+						'default' => false,
+					],
+					'cookiePolicyHTML' => [
+						'property' => 'cookiePolicyHTML',
+						'type' => 'html',
+						'label' => 'Cookie Policy',
+						'description' => 'HTML of cookie policy to display to users',
+						'default' => 'This body has not yet set a cookie storage policy, please check back later.',
+						'hideInLists' => true,
+					],
+					'trackIpAddresses' => [
+						'property' => 'trackIpAddresses',
+						'type' => 'checkbox',
+						'label' => 'Track IP Addresses',
+						'description' => 'Determine if IP Addresses should be tracked for each page view',
+						'default' => false,
+					]
+				]
 			],
 		];
 	}


### PR DESCRIPTION
This patch adds a Cookie consent banner for GDPR purposes. It can be toggled on under system variables and additionally allows you to add your cookie policy as html to be displayed when the user requests more information.

Test plan:
 - Log in as aspen_admin user
 - Navigate to system variables in the administration menu
 - Click edit and scroll to bottom
 - Notice new data protection section and toggle cookie consent on. Save changes.
 - *New cookie consent banner should now appear*
 - Set new cookie policy HTML in same section of system variables.
 - Notice these changes are shown when more information is requested on the cookie consent banner
 - Accept cookies and check cookie is assigned correctly in browser dev tools.
 - Check that IP storage checkbox still works as intended in new data protection section, then navigating to "Usage by IP" in the administration section.
When checked: IP addresses should be listed.
When not checked: This page should not list any IP addresses