### PR TITLE
Refactor: Updating language and display options to be included in burger menu f…

### DIFF
--- a/code/web/interface/themes/responsive/css-rtl/layout.less
+++ b/code/web/interface/themes/responsive/css-rtl/layout.less
@@ -145,6 +145,10 @@ hr.menu{
   }
 }
 
+#home-page-language-selection i{
+  cursor: auto;
+}
+
 #account-menu {
   right: unset;
   left: 0;
@@ -171,17 +175,40 @@ hr.menu{
   cursor: pointer;
 }
 
-#aspenLanguagesMenuSection {
+.header-menu-section.heading-for-options {
+  cursor: auto;
+  color: #3174AF;
   font-weight: bold;
   margin-top: 1em;
 }
 
+.header-menu-section.heading-for-options i{
+  margin-left: 0.5em;
+}
+
 .header-menu-option.languageSelect {
-  margin-right: 2em;
+  margin-right: 1.5em;
+}
+.header-menu-option.themeSelect {
+  margin-right: 1.5em;
 }
 
 .header-menu-option.languageSelected {
-  margin-right: .5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected {
+  color: #3174AF;
+}
+
+.header-menu-option.languageSelected i {
+  margin-right: 1.5em;
+  margin-left: 0.5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected i {
+  margin-right: 1.5em;
+  margin-left: 0.5em;
+  color: #3174AF;
 }
 
 #library-name-header{
@@ -885,4 +912,11 @@ a.placard-link{
   border-radius: 50%;
   height: 60px;
   width: 60px;
+}
+
+#translationMode {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  text-align: left;
+  padding-top: 0.5em;
 }

--- a/code/web/interface/themes/responsive/css-rtl/main.css
+++ b/code/web/interface/themes/responsive/css-rtl/main.css
@@ -8007,6 +8007,9 @@ hr.menu {
 .header-menu-option i + span {
   margin-right: 0.5em;
 }
+#home-page-language-selection i {
+  cursor: auto;
+}
 #account-menu {
   right: unset;
   left: 0;
@@ -8029,15 +8032,36 @@ hr.menu {
   margin-bottom: 3px;
   cursor: pointer;
 }
-#aspenLanguagesMenuSection {
+.header-menu-section.heading-for-options {
+  cursor: auto;
+  color: #3174AF;
   font-weight: bold;
   margin-top: 1em;
 }
+.header-menu-section.heading-for-options i {
+  margin-left: 0.5em;
+}
 .header-menu-option.languageSelect {
-  margin-right: 2em;
+  margin-right: 1.5em;
+}
+.header-menu-option.themeSelect {
+  margin-right: 1.5em;
 }
 .header-menu-option.languageSelected {
-  margin-right: 0.5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected {
+  color: #3174AF;
+}
+.header-menu-option.languageSelected i {
+  margin-right: 1.5em;
+  margin-left: 0.5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected i {
+  margin-right: 1.5em;
+  margin-left: 0.5em;
+  color: #3174AF;
 }
 #library-name-header {
   font-size: 26px;
@@ -8660,6 +8684,12 @@ a.placard-link {
   border-radius: 50%;
   height: 60px;
   width: 60px;
+}
+#translationMode {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  text-align: left;
+  padding-top: 0.5em;
 }
 #home-page-search {
   background-color: #00a4e3;

--- a/code/web/interface/themes/responsive/css/layout.less
+++ b/code/web/interface/themes/responsive/css/layout.less
@@ -141,6 +141,9 @@ hr.menu{
     margin-left: .5em;
   }
 }
+#home-page-language-selection i{
+  cursor: auto;
+}
 
 #account-menu {
   left: unset;
@@ -167,17 +170,50 @@ hr.menu{
   cursor: pointer;
 }
 
-#aspenLanguagesMenuSection {
+.header-menu-section.heading-for-options {
+  cursor: auto;
+  color: #3174AF;
   font-weight: bold;
   margin-top: 1em;
 }
 
+.header-menu-section.heading-for-options i{
+  margin-right: 0.5em;
+}
+
 .header-menu-option.languageSelect {
-  margin-left: 2em;
+  margin-left: 1.5em;
+}
+
+.header-menu-option.themeSelect {
+  margin-left: 1.5em;
 }
 
 .header-menu-option.languageSelected {
-  margin-left: .5em;
+  color: #3174AF;
+}
+
+.header-menu-option.themeSelected {
+  color: #3174AF;
+}
+
+.header-menu-option.languageSelected i{
+  margin-left: 1.5em;
+  margin-right: 0.5em;
+  color: #3174AF;
+}
+
+.header-menu-option.themeSelected i{
+  margin-left: 1.5em;
+  margin-right: 0.5em;
+  color: #3174AF;
+}
+
+#translationMode {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  text-align: right;
+  padding-top: 0.5em;
 }
 
 #library-name-header{

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -8019,6 +8019,9 @@ hr.menu {
 .header-menu-option i + span {
   margin-left: 0.5em;
 }
+#home-page-language-selection i {
+  cursor: auto;
+}
 #account-menu {
   left: unset;
   right: 0;
@@ -8040,15 +8043,42 @@ hr.menu {
   margin-bottom: 3px;
   cursor: pointer;
 }
-#aspenLanguagesMenuSection {
+.header-menu-section.heading-for-options {
+  cursor: auto;
+  color: #3174AF;
   font-weight: bold;
   margin-top: 1em;
 }
+.header-menu-section.heading-for-options i {
+  margin-right: 0.5em;
+}
 .header-menu-option.languageSelect {
-  margin-left: 2em;
+  margin-left: 1.5em;
+}
+.header-menu-option.themeSelect {
+  margin-left: 1.5em;
 }
 .header-menu-option.languageSelected {
-  margin-left: 0.5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected {
+  color: #3174AF;
+}
+.header-menu-option.languageSelected i {
+  margin-left: 1.5em;
+  margin-right: 0.5em;
+  color: #3174AF;
+}
+.header-menu-option.themeSelected i {
+  margin-left: 1.5em;
+  margin-right: 0.5em;
+  color: #3174AF;
+}
+#translationMode {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  text-align: right;
+  padding-top: 0.5em;
 }
 #library-name-header {
   font-size: 26px;

--- a/code/web/interface/themes/responsive/header-menu.tpl
+++ b/code/web/interface/themes/responsive/header-menu.tpl
@@ -96,18 +96,16 @@
 		{/foreach}
 	{/if}
 
-	{if count($validLanguages) > 1}
-		<div class="header-menu-section" id="aspenLanguagesMenuSection">
-			<i class="fas fa-globe fa-fw"></i>{translate text="Language" isPublicFacing=true}
+		<div id="aspenLanguagesMenuSection" class="header-menu-section heading-for-options">
+			<i class="fas fa-globe fa-wa"></i>{translate text="Language" isPublicFacing=true}
 		</div>
-
 		{foreach from=$validLanguages key=languageCode item=language}
 			{if $userLang->code!=$languageCode}
 			<a onclick="return AspenDiscovery.setLanguage('{$languageCode}')">
 			{/if}
 				<div class="header-menu-option languageSelect{if $userLang->code==$languageCode}ed{/if}">
 					{if $userLang->code==$languageCode}
-						<i class="fas fa-check fa-fw"></i>&nbsp;
+						<i class="fas fa-check fa-fw"></i>
 					{/if}
 					{$language->displayName}
 				</div>
@@ -115,7 +113,22 @@
 			</a>
 			{/if}
 		{/foreach}
-	{/if}
+
+		<div class="header-menu-section heading-for-options" id="aspenThemesMenuSection">
+			<i class="fas fa-cog fa-wa"></i>{translate text="Display" isPublicFacing=true}
+		</div>
+
+		{foreach from=$allActiveThemes key=themeId item=themeName}
+		<div class="header-menu-option themeSelect{if $themeId === $activeTheme}ed{/if}">
+			{if $themeId === $activeTheme}
+				<i class="fas fa-check fa-fw"></i>
+			{/if}
+			<li><a onclick="return AspenDiscovery.setTheme('{$themeId}')">
+				{$themeName}
+			</a></li>
+			</div>
+		{/foreach}
+	
 
 	{if !empty($masqueradeMode)}
 		<a class="btn btn-default btn-sm btn-block" onclick="AspenDiscovery.Account.endMasquerade()">{translate text="End Masquerade" isAdminFacing=true}</a>

--- a/code/web/interface/themes/responsive/header_responsive.tpl
+++ b/code/web/interface/themes/responsive/header_responsive.tpl
@@ -32,91 +32,15 @@
 			</a>
 		</div>
 	{/if}
-	{if count($validLanguages) > 1 || count($allActiveThemes) > 1}
-		<div id="language-selection-header" class="col-tn-12 col-xs-4 col-sm-4 col-md-4 col-lg-4 pull-right">
-			<a id="theme-selection-dropdown" class="btn btn-default btn-sm" {if !empty($loggedIn)}href="/MyAccount/MyPreferences" {else} onclick="AspenDiscovery.showDisplaySettings()"{/if}>
-				{if count($validLanguages) > 1 && count($allActiveThemes) > 1}
-					{translate text="Languages & Display" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
-				{elseif count($validLanguages) > 1}
-					{translate text="Languages" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
+	{if count($validLanguages) > 1}
+		{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
+			<div id="translationMode" class="col-tn-12 col-xs-4 col-sm-4 col-md-4 col-lg-4 pull-right">
+				{if !empty($translationModeActive)}
+					<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
 				{else}
-					{translate text="Display" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
+					<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
 				{/if}
-			</a>
-			{if count($validLanguages) > 1}
-				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
-					<div id="translationMode" style="padding-top:.5em">
-						{if !empty($translationModeActive)}
-							<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
-						{else}
-							<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
-						{/if}
-					</div>
-				{/if}
-			{/if}
-		</div>
-		<div style="display: none">
-		<div id="language-selection-header" class="col-tn-12 col-xs-4 col-sm-4 col-md-4 col-lg-4 pull-right">
-			{if count($validLanguages) == 2}
-				<div class="btn-group btn-group-sm" role="group">
-				{foreach from=$validLanguages key=languageCode item=language}
-					<div class="availableLanguage btn btn-sm btn-default {if $userLang->code==$languageCode}active{/if}">
-					{if $userLang->code!=$languageCode}
-					<a onclick="return AspenDiscovery.setLanguage('{$languageCode}')" role="button">
-					{/if}
-						<div>
-							{$language->displayName}
-						</div>
-					{if $userLang->code!=$languageCode}
-					</a>
-					{/if}
-					</div>
-				{/foreach}
-				</div>
-				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
-					<div id="translationMode" style="padding-top:.5em">
-						{if !empty($translationModeActive)}
-							<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
-						{else}
-							<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
-						{/if}
-					</div>
-				{/if}
-			{elseif count($validLanguages) >= 3}
-				<div class="dropdown">
-					<button class="btn btn-default btn-sm dropdown-toggle" type="button" id="language-selection-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{translate text="Languages" isPublicFacing=true}&nbsp;<span class="caret"></span>
-					</button>
-					<ul id="select-language" class="dropdown-menu" aria-labelledby="language-selection-dropdown">
-						{foreach from=$validLanguages key=languageCode item=language}
-							<li><a onclick="return AspenDiscovery.setLanguage('{$languageCode}')">{$language->displayName}</a></li>
-						{/foreach}
-					</ul>
-				</div>
-
-				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
-					<div id="translationMode">
-						{if !empty($translationModeActive)}
-							<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
-						{else}
-							<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
-						{/if}
-					</div>
-				{/if}
-			{/if}
-			{if count($allActiveThemes) > 1}
-				<div class="dropdown">
-					<button class="btn btn-default btn-sm dropdown-toggle" type="button" id="theme-selection-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{translate text="Display" isPublicFacing=true}&nbsp;<span class="caret"></span>
-					</button>
-					<ul id="select-theme" class="dropdown-menu" aria-labelledby="theme-selection-dropdown">
-						{foreach from=$allActiveThemes key=themeId item=themeName}
-							<li><a onclick="return AspenDiscovery.setTheme('{$themeId}')">{$themeName}</a></li>
-						{/foreach}
-					</ul>
-				</div>
-			{/if}
-		</div>
-		</div>
+			</div>
+		{/if}
 	{/if}
 {/strip}


### PR DESCRIPTION
The burger menu now contains a section for languages, which displays all languages currently active on the user's account and a section for displays to reflect the themes available.  This supports accessibility and creates continuity between the display whether logged in or not. 
To Test:
1)Prior to implementation, if not logged in you should see a button in the header that will read  "Languages and Display" or "Languages". When clicked, a modal opens up so that you can make your selection. 
2)Log in and note that to change the language, you need to use the burger menu. Click on an available language and note that you are taken to a preferences page. 
3)Implement new code and note that you are not shown the "Languages and Display" button, regardless of whether you are logged in or not. 
4)Use the burger menu to select an available language and note that the language can now be selected directly from the menu, the page should not redirect you, but alter the display so that it is now in your chosen language. 

