### PR TITLE
Fix: Mobile Browsing

### DIFF
--- a/code/web/interface/themes/responsive/css-rtl/results-list.less
+++ b/code/web/interface/themes/responsive/css-rtl/results-list.less
@@ -138,9 +138,11 @@
 .result-title{
   font-weight: bold;
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-index{
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-tools-horizontal{
   margin-top: 6px;
@@ -157,14 +159,13 @@
   border-bottom: 1px solid #d5d6da;
 }
 .related-manifestations{
-  margin-top: 3px;
+  margin-top: 1px;
 }
 .related-manifestation.grouped {
   padding-top: 10px;
   padding-bottom: 10px;
   border: 1px solid #c3c3c3;
   border-radius: 8px;
-  margin-top: 1em;
 
   .col-sm-12 .row.displayed {
     padding-bottom: 1em;
@@ -289,18 +290,45 @@
     padding-left: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+    padding: 5px 10px;
+    font-size: 12px;
+    line-height: 1.5;
+    border-radius: 3px;
   }
+}
+@media (max-width:390px) {
+  #global,
+  #local,
+  #available {
+    padding: 1px 5px;
+    font-size: 10px;
+    line-height: 1.5;
+    border-radius: 3px;
+  }
+}
+@media (max-width:310px) {
+  #global,
+  #local,
+  #available {
+    padding: 0px;
+    line-height: 0.8;
+    font-size:8px;
+    min-height: 75px;
+  }
+  #availabilityControlContainer {
+    border-bottom: 3px solid #d5d6da;
+    margin-top: 0;
+    min-height: 75px;
+    margin-bottom: 2px;
+  }
+}
   //.title-rating {
   //  display: none;
   //}
-}
-
 //// Hide Formats label when shown in modal pop-up
 //.modal .related-manifestations-header {
 //  display: none;
 //}
-
 .search-results-navigation {
   display: flex;
   flex-direction: row;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -10207,9 +10207,11 @@ a.browse-thumbnail-sorted.active {
 .result-title {
   font-weight: bold;
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-index {
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-tools-horizontal {
   margin-top: 6px;
@@ -10220,14 +10222,13 @@ a.browse-thumbnail-sorted.active {
   border-bottom: 1px solid #d5d6da;
 }
 .related-manifestations {
-  margin-top: 3px;
+  margin-top: 1px;
 }
 .related-manifestation.grouped {
   padding-top: 10px;
   padding-bottom: 10px;
   border: 1px solid #c3c3c3;
   border-radius: 8px;
-  margin-top: 1em;
 }
 .related-manifestation.grouped .col-sm-12 .row.displayed {
   padding-bottom: 1em;
@@ -10355,6 +10356,32 @@ a.browse-thumbnail-sorted.active {
     font-size: 12px;
     line-height: 1.5;
     border-radius: 3px;
+  }
+}
+@media (max-width: 400px) and (max-width: 390px) {
+  #global,
+  #local,
+  #available {
+    padding: 1px 5px;
+    font-size: 10px;
+    line-height: 1.5;
+    border-radius: 3px;
+  }
+}
+@media (max-width: 310px) {
+  #global,
+  #local,
+  #available {
+    padding: 0px;
+    font-size: 8px;
+    line-height: 0.8;
+    min-height: 75px;
+  }
+  #availabilityControlContainer {
+    border-bottom: 3px solid #d5d6da;
+    margin-top: 0;
+    min-height: 75px;
+    margin-bottom: 2px;
   }
 }
 .search-results-navigation {

--- a/code/web/interface/themes/responsive/css/results-list.less
+++ b/code/web/interface/themes/responsive/css/results-list.less
@@ -138,9 +138,11 @@
 .result-title{
   font-weight: bold;
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-index{
   font-size: 18px;
+  margin-top: 12px;
 }
 .result-tools-horizontal{
   margin-top: 6px;
@@ -157,14 +159,13 @@
   border-bottom: 1px solid #d5d6da;
 }
 .related-manifestations{
-  margin-top: 3px;
+  margin-top: 1px;
 }
 .related-manifestation.grouped {
   padding-top: 10px;
   padding-bottom: 10px;
   border: 1px solid #c3c3c3;
   border-radius: 8px;
-  margin-top: 1em;
 
   .col-sm-12 .row.displayed {
     padding-bottom: 1em;
@@ -289,11 +290,40 @@
     padding-right: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+      padding: 5px 10px;
+      font-size: 12px;
+      line-height: 1.5;
+      border-radius: 3px;
+  }
+  @media (max-width:390px) {
+    #global,
+    #local,
+    #available {
+      padding: 1px 5px;
+      font-size: 10px;
+      line-height: 1.5;
+      border-radius: 3px;
+    }
   }
   //.title-rating {
   //  display: none;
   //}
+}
+@media (max-width:310px) {
+  #global, 
+  #local,
+  #available {
+      padding: 0px;
+      font-size: 8px;
+      line-height: 0.8;
+      min-height: 75px; 
+   }
+   #availabilityControlContainer {
+      border-bottom: 3px solid #d5d6da;
+      margin-top: 0;
+      min-height: 75px;
+      margin-bottom: 2px;
+     }
 }
 
 //// Hide Formats label when shown in modal pop-up


### PR DESCRIPTION
Minor changes made to the CSS to ensure that the buttons for availability remain consistent in size with each other when viewing on smaller devices and a small adjustment to ensure that the border around each of the listed results surrounds the title and the title does not appear to be crossed out by the line. 

Test Plan: (Carry out a search that produces multiple results)
1) Set browser to responsive viewing or choose a mobile browsing device. As the screen gets smaller, note that the "Entire Collection" tab becomes taller than the "Centerville" and "Available Now" tabs at some screen widths. 
2) Note that on larger screens, there is a grey border around the "books, on shelf" section of each result. As the screen gets smaller, this border changes to enclose the entire result. The top of the border appears to strike through the title at some widths.
3)Apply the changes and carry out a search that produces multiple results. Note that the availability buttons are all sized consistently with each other at all screen widths and that the grey border does not appear to be striking through the result title and index. 