### PR TITLE
Feat: Ability to hide name in public lists

### DIFF
--- a/code/user_list_indexer/src/com/turning_leaf_technologies/reindexer/UserListIndexer.java
+++ b/code/user_list_indexer/src/com/turning_leaf_technologies/reindexer/UserListIndexer.java
@@ -184,6 +184,7 @@ class UserListIndexer {
 		int deleted = allPublicListsRS.getInt("deleted");
 		int isPublic = allPublicListsRS.getInt("public");
 		int isSearchable = allPublicListsRS.getInt("searchable");
+		int isDisplayListAuthor = allPublicListsRS.getInt("displayListAuthor");
 		long userId = allPublicListsRS.getLong("user_id");
 		boolean indexed = false;
 		if (!fullReindex && (deleted == 1 || isPublic == 0 || isSearchable == 0)){
@@ -208,8 +209,8 @@ class UserListIndexer {
 				}else{
 					userListSolr.setOwnerCanShareListsInSearchResults(usersThatCanShareLists.contains(userId));
 				}
-				if (displayName != null && displayName.length() > 0){
-					userListSolr.setAuthor(displayName);
+				if (displayName != null && displayName.length() > 0 && isDisplayListAuthor == 1){
+						userListSolr.setAuthor(displayName);
 				}else{
 					if (firstName == null) firstName = "";
 					if (lastName == null) lastName = "";

--- a/code/web/RecordDrivers/ListsRecordDriver.php
+++ b/code/web/RecordDrivers/ListsRecordDriver.php
@@ -59,7 +59,6 @@ class ListsRecordDriver extends IndexRecordDriver {
 		}
 
 		global $interface;
-
 		$id = $this->getUniqueID();
 		$interface->assign('summId', $id);
 		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('medium'));
@@ -78,6 +77,9 @@ class ListsRecordDriver extends IndexRecordDriver {
 		}
 		$interface->assign('summDateUpdated', $this->getListObject()->dateUpdated);
 		$interface->assign('summUrl', $this->getAbsoluteUrl());
+
+		$listObject = $this->getListObject();
+		$interface->assign('displayListAuthor', $listObject->displayListAuthor);
 
 		if ($showListsAppearingOn) {
 			//Check to see if there are lists the record is on
@@ -195,6 +197,4 @@ class ListsRecordDriver extends IndexRecordDriver {
 		}
 		return $this->listObject;
 	}
-
-
 }

--- a/code/web/interface/themes/responsive/MyAccount/createListForm.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/createListForm.tpl
@@ -26,7 +26,7 @@
 		<div class="form-group">
 			<label for="public" class="col-sm-3 control-label">{translate text="Access" isPublicFacing=true}</label>
 			<div class="col-sm-9">
-				<input type='checkbox' name='public' id='public' data-on-text="{translate text="Public" isPublicFacing=true}" data-off-text="{translate text="Private" isPublicFacing=true}" {if in_array('Include Lists In Search Results', $userPermissions)}onchange="if($(this).prop('checked') === true){ldelim}$('#searchableRow').show(){rdelim}else{ldelim}$('#searchableRow').hide(){rdelim}"{/if}/>
+				<input type='checkbox' name='public' id='public' data-on-text="{translate text="Public" isPublicFacing=true}" data-off-text="{translate text="Private" isPublicFacing=true}" {if in_array('Include Lists In Search Results', $userPermissions)}onchange="if($(this).prop('checked') === true){ldelim}$('#searchableRow').show();$('#displayListAuthorRow').show(){rdelim}else{ldelim}$('#searchableRow').hide();$('#displayListAuthorRow').hide(){rdelim}"{/if}/>
 				<div class="form-text text-muted">
 					<small>{translate text="Public lists can be shared with other people by copying the URL of the list or using the Email List button when viewing the list." isPublicFacing=true}</small>
 				</div>
@@ -45,14 +45,29 @@
 				</div>
 			{/if}
 		{/if}
-		<input type="hidden" name="source" value="{if !empty($source)}{$source}{/if}">
+		{if !empty($userPermissions)}
+		{if in_array('Include Lists In Search Results', $userPermissions)}
+			<div class="form-group" id="displayListAuthorRow" style="display: none">
+				<label for="displayListAuthor" class="col-sm-3 control-label">{translate text="Show list author in search results" isPublicFacing=true}</label>
+				<div class="col-sm-9">
+					<input type='checkbox' name='displayListAuthor' id='displayListAuthor' data-on-text="{translate text="Yes" isPublicFacing=true}" data-off-text="{translate text="No" isPublicFacing=true}" checked/>
+					<div class="form-text text-muted">
+						<small>{translate text="If enabled, your name will be displayed as the author of public lists." isPublicFacing=true}</small>
+					</div>
+				</div>
+			</div>	
+		{/if}
+		{/if}
+	<input type="hidden" name="source" value="{if !empty($source)}{$source}{/if}">
 		<input type="hidden" name="sourceId" value="{if !empty($sourceId)}{$sourceId}{/if}">
 	</form>
 	<br/>
 {/strip}
-<script type="text/javascript">{literal}
+<script type="text/javascript">
+{literal}
 	$(document).ready(function(){
 		var publicSwitch = $('#public').bootstrapSwitch();
 		var searchableSwitch = $('#searchable').bootstrapSwitch();
+		var displayListAuthorSwitch = $('#displayListAuthor').bootstrapSwitch();
 	});
 {/literal}</script>

--- a/code/web/interface/themes/responsive/MyAccount/list.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/list.tpl
@@ -77,6 +77,17 @@
 										</div>
 									</div>
 								{/if}
+								{if in_array('Include Lists In Search Results', $userPermissions)}
+								<div class="form-group" id="displayListAuthorRow" {if $userList->public == 0}style="display: none"{/if}>
+									<label for="displayListAuthor" class="col-sm-3 control-label">{translate text="Show list author in search results" isPublicFacing=true}</label>
+									<div class="col-sm-9">
+										<input type='checkbox' name='displayListAuthor' id='displayListAuthor' data-on-text="Yes" data-off-text="No" {if $userList->displayListAuthor == 1}checked{/if}/>
+										<div class="form-text text-muted">
+											<small>{translate text="If enabled, your name will be displayed as the author of public lists." isPublicFacing=true}</small>
+										</div>
+									</div>
+								</div>
+							{/if}
 								{if in_array('Upload List Covers', $userPermissions)}
 									<div class="form-group" id="searchableRow" {if $userList->public == 0}style="display: none"{/if}>
 										<label for="searchable" class="col-sm-3 control-label">{translate text="Upload custom list cover" isPublicFacing=true}</label>
@@ -87,10 +98,12 @@
 									</div>
 								{/if}
 							</div>
-							<script type="text/javascript">{literal}
+							<script type="text/javascript">
+							{literal}
 								$(document).ready(function(){
 									$('#public').bootstrapSwitch();
 									$('#searchable').bootstrapSwitch();
+									$('#displayListAuthor').bootstrapSwitch();
 								});
 							{/literal}</script>
 						{/if}

--- a/code/web/interface/themes/responsive/MyAccount/lists.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/lists.tpl
@@ -102,13 +102,12 @@
 					</div>
 
 					<div class="row">
-						<div class="col-xs-12"><span class="badge">{if $list->public == '0'}{translate text="Private" isPublicFacing=true}{else}{translate text="Public" isPublicFacing=true}{/if}</span> {if $list->searchable == '1' && $list->public == '1'}<span class="badge">{translate text="Searchable" isPublicFacing=true}</span>{/if}</div>
+						<div class="col-xs-12"><span class="badge">{if $list->public == '0'}{translate text="Private" isPublicFacing=true}{else}{translate text="Public" isPublicFacing=true}{/if}</span> {if $list->searchable == '1' && $list->public == '1'}<span class="badge">{translate text="Searchable" isPublicFacing=true}</span>{/if}{if $list->displayListAuthor == '1'}<span class="badge">{translate text="Display List Author" isPublicFacing=true}{/if}</div>
 					</div>
 
 				</div>
 			</div>
 		{/foreach}
-
 		{if !empty($pageLinks.all)}<div class="pagination">{$pageLinks.all}</div>{/if}
 	{/if}
 {/strip}

--- a/code/web/interface/themes/responsive/RecordDrivers/List/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/List/result.tpl
@@ -16,7 +16,7 @@
 
 		<div class="row">
 			<div class="col-xs-12">
-				<span class="result-index">{$resultIndex})</span>&nbsp;
+	<span class="result-index">{$resultIndex})</span>&nbsp;
 				<a href="/MyAccount/MyList/{$summShortId}" class="result-title notranslate">
 					{if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|highlight|truncate:180:"..."}{/if}
 				</a>
@@ -25,10 +25,10 @@
 				{/if}
 			</div>
 		</div>
-
 		{if !empty($summAuthor)}
 			<div class="row">
 				<div class="result-label col-tn-3">{translate text="Created By" isPublicFacing=true} </div>
+				{if $displayListAuthor == 1}
 				<div class="result-value col-tn-9 notranslate">
 					{if is_array($summAuthor)}
 						{foreach from=$summAuthor item=author}
@@ -38,9 +38,14 @@
 						{$summAuthor|highlight}
 					{/if}
 				</div>
+				{else}
+					<div class="result-value col-tn-9">
+						{translate text="Anonymous"}
+					</div>
+				{/if}
 			</div>
 		{/if}
-
+ 
 		{if !empty($summNumTitles)}
 			<div class="row">
 				<div class="result-label col-tn-3">{translate text="Number of Titles" isPublicFacing=true} </div>

--- a/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
@@ -35,6 +35,7 @@
 	{/if}
 {else}
 	{* Simple list with more link to show remaining values (if any) *}
+	{if $displayListAuthor == 1}
 	{foreach from=$cluster.list item=thisFacet name="narrowLoop"}
 		{if $smarty.foreach.narrowLoop.iteration == ($cluster.valuesToShow + 1)}
 		{* Show More link*}
@@ -54,5 +55,6 @@
 			<a href="#" onclick="AspenDiscovery.ResultsList.lessFacets('{$title}'); return false;">{translate text='less' isPublicFacing=true} ...</a>
 		</div>
 		</div>{* closes hidden div *}
+	{/if}
 	{/if}
 {/if}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5354,6 +5354,11 @@ AspenDiscovery.Account = (function () {
 			if (searchableControl) {
 				isSearchable = searchableControl.prop("checked");
 			}
+			var isDisplayListAuthor = false;
+			var displayListAuthorControl = $("#displayListAuthor");
+			if (displayListAuthorControl) {
+				isDisplayListAuthor = displayListAuthorControl.prop("checked");
+			}
 			var titleInput = form.find("input[name=title]");
 			var title;
 			if (titleInput.length > 0){
@@ -5369,6 +5374,7 @@ AspenDiscovery.Account = (function () {
 				title: title,
 				public: isPublic,
 				searchable: isSearchable,
+				displayListAuthor: isDisplayListAuthor,
 				desc: desc,
 				source: source,
 				sourceId: sourceId

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -29,6 +29,11 @@ AspenDiscovery.Account = (function () {
 			if (searchableControl) {
 				isSearchable = searchableControl.prop("checked");
 			}
+			var isDisplayListAuthor = false;
+			var displayListAuthorControl = $("#displayListAuthor");
+			if (displayListAuthorControl) {
+				isDisplayListAuthor = displayListAuthorControl.prop("checked");
+			}
 			var titleInput = form.find("input[name=title]");
 			var title;
 			if (titleInput.length > 0){
@@ -44,6 +49,7 @@ AspenDiscovery.Account = (function () {
 				title: title,
 				public: isPublic,
 				searchable: isSearchable,
+				displayListAuthor: isDisplayListAuthor,
 				desc: desc,
 				source: source,
 				sourceId: sourceId

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -130,6 +130,7 @@ class ListAPI extends Action {
 					'id' => $list->id,
 					'title' => $list->title,
 					'description' => $list->description,
+					'displayListAuthor' => $list->displayListAuthor,
 					'numTitles' => $numTitles,
 					'dateUpdated' => $list->dateUpdated,
 				];
@@ -199,6 +200,7 @@ class ListAPI extends Action {
 				if ($success) {
 					$row = $stmt->fetch();
 					$numTitles = $row['numTitles'];
+					// $displayListAuthor = $list['displayListAuthor'];
 				} else {
 					$numTitles = -1;
 				}
@@ -207,6 +209,7 @@ class ListAPI extends Action {
 					'id' => $list->id,
 					'title' => $list->title,
 					'description' => $list->description,
+					'displayListAuthor' => $list->displayListAuthor,
 					'numTitles' => $numTitles,
 					'dateUpdated' => $list->dateUpdated,
 				];
@@ -260,6 +263,7 @@ class ListAPI extends Action {
 							'id' => $list->id,
 							'title' => $list->title,
 							'description' => $list->description,
+							'displayListAuthor' => $list->displayListAuthor == 1,
 							'numTitles' => $list->numValidListItems(),
 							'public' => $list->public == 1,
 							'created' => $list->created,
@@ -273,6 +277,7 @@ class ListAPI extends Action {
 						'id' => $list->id,
 						'title' => $list->title,
 						'description' => $list->description,
+						'displayListAuthor' => $list->displayListAuthor == 1,
 						'numTitles' => $list->numValidListItems(),
 						'public' => $list->public == 1,
 						'created' => $list->created,
@@ -759,6 +764,7 @@ class ListAPI extends Action {
 					'id' => $list->id,
 					'title' => $list->title,
 					'description' => $list->description,
+					'displayListAuthor' => $list->displayListAuthor == 1 ? $list['author_display'] : '',
 					'numTitles' => $list->numValidListItems(),
 					'public' => $list->public,
 					'created' => $list->created,
@@ -1082,6 +1088,7 @@ class ListAPI extends Action {
 
 			$list->description = strip_tags($_REQUEST['description'] ?? '');
 			$list->public = isset($_REQUEST['public']) ? (($_REQUEST['public'] == true || $_REQUEST['public'] == 1) ? 1 : 0) : 0;
+			$list->displayListAuthor = isset($_REQUEST['displayListAuthor']) ? (($_REQUEST['displayListAuthor'] == true || $_REQUEST['public'] == 1) ? 1 : 0) : 0;
 
 			if ($existingList) {
 				$list->update();
@@ -1380,6 +1387,13 @@ class ListAPI extends Action {
 						$list->public = 0;
 					} else {
 						$list->public = 1;
+					}
+				}
+				if (isset($_REQUEST['displayListAuthor'])) {
+					if ($_REQUEST['displayListAuthor'] === "false" || $_REQUEST['displayListAuthor'] === false || $_REQUEST['displayListAuthor'] === 0 || $_REQUEST['displayListAuthor'] === '0') {
+						$list->displayListAuthor = 0;
+					} else {
+						$list->displayListAuthor = 1;
 					}
 				}
 				$list->update();

--- a/code/web/services/API/SearchAPI.php
+++ b/code/web/services/API/SearchAPI.php
@@ -1021,9 +1021,14 @@ class SearchAPI extends Action {
 				$jsonResults[] = [
 					'id' => $record['id'],
 					'title' => isset($record['title_display']) ? $record['title_display'] : null,
-					'author' => isset($record['author_display']) ? $record['author_display'] : (isset($record['author2']) ? $record['author2'] : ''),
 					'format' => isset($record['format_' . $solrScope]) ? $record['format_' . $solrScope] : '',
 					'format_category' => isset($record['format_category_' . $solrScope]) ? $record['format_category_' . $solrScope] : '',
+					'author' => ($displayListAuthor == 0) 
+						? null
+						: (isset($record['author_display'])
+							? $record['author_display']
+							: (isset($record['author2']) ?
+							$record['author2'] : '')),
 				];
 			}
 		}

--- a/code/web/services/Lists/Results.php
+++ b/code/web/services/Lists/Results.php
@@ -47,7 +47,6 @@ class Lists_Results extends ResultsAction {
 
 		// Hide Covers when the user has set that setting on the Search Results Page
 		$this->setShowCovers();
-
 		$timer->logTime('Setup Search');
 
 		// Process Search
@@ -105,6 +104,7 @@ class Lists_Results extends ResultsAction {
 		$interface->assign('savedSearch', $searchObject->isSavedSearch());
 		$interface->assign('searchId', $searchObject->getSearchId());
 		$currentPage = isset($_REQUEST['page']) ? $_REQUEST['page'] : 1;
+
 		$interface->assign('page', $currentPage);
 
 		if ($searchObject->getResultTotal() == 0) {

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -1242,6 +1242,7 @@ class MyAccount_AJAX extends JSON_Action {
 				$list->description = strip_tags(urldecode($desc));
 				$list->public = isset($_REQUEST['public']) && $_REQUEST['public'] == 'true';
 				$list->searchable = isset($_REQUEST['searchable']) && $_REQUEST['searchable'] == 'true';
+				$list->displayListAuthor = isset($_REQUEST['displayListAuthor']) && $_REQUEST['displayListAuthor'] == 'true';
 				if ($existingList) {
 					$list->update();
 				} else {

--- a/code/web/services/MyAccount/Lists.php
+++ b/code/web/services/MyAccount/Lists.php
@@ -45,6 +45,7 @@ class Lists extends MyAccount {
 			'totalItems' => $listCount,
 			'perPage' => $listsPerPage,
 			'showCovers' => isset($_REQUEST['showCovers']),
+			'displayListAuthor' => isset($_REQUEST['displayListAuthor']),
 		];
 		$pager = new Pager($options);
 

--- a/code/web/services/MyAccount/MyList.php
+++ b/code/web/services/MyAccount/MyList.php
@@ -90,8 +90,10 @@ class MyAccount_MyList extends MyAccount {
 					$list->public = isset($_REQUEST['public']) && ($_REQUEST['public'] == 'true' || $_REQUEST['public'] == 'on');
 					if (!$list->public) {
 						$list->searchable = false;
+						$list->displayListAuthor = false;
 					} else {
 						$list->searchable = isset($_REQUEST['searchable']) && ($_REQUEST['searchable'] == 'true' || $_REQUEST['searchable'] == 'on');
+						$list->displayListAuthor = isset($_REQUEST['displayListAuthor']) && ($_REQUEST['displayListAuthor'] == 'true' || $_REQUEST['displayListAuthor'] == 'on');
 					}
 					$this->reloadCover();
 					$list->update();

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -160,5 +160,16 @@ function getUpdates23_08_00(): array {
 			]
 		],
 
+		//Alexander - PTFS
+		'display_list_author_control' => [
+			'title' => 'User List Author Control',
+			'description' => 'Add a setting to allow users to control whether their name appears on public lists they have created.',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE  user_list ADD COLUMN displayListAuthor TINYINT(1) DEFAULT 0',
+				'ALTER TABLE user ADD COLUMN displayListAuthor TINYINT(1) DEFAULT 0',
+			],
+		],
+
 	];
 }

--- a/code/web/sys/SearchObject/ListsSearcher.php
+++ b/code/web/sys/SearchObject/ListsSearcher.php
@@ -231,23 +231,71 @@ class SearchObject_ListsSearcher extends SearchObject_SolrSearcher {
 	}
 
 	//TODO: Convert this to use definitions so they can be customized in admin
-	public function getFacetConfig() {
-		if ($this->facetConfig == null) {
-			$facetConfig = [];
-			$author = new LibraryFacetSetting();
-			$author->id = 1;
-			$author->multiSelect = true;
-			$author->facetName = "author_display";
-			$author->displayName = "Created By";
-			$author->numEntriesToShowByDefault = 5;
-			$author->translate = true;
-			$author->collapseByDefault = false;
-			$author->useMoreFacetPopup = true;
-			$facetConfig["author_display"] = $author;
+	// public function getFacetConfig() {
+	// 	require_once ROOT_DIR . '/RecordDrivers/ListsRecordDriver.php';
 
+	// 	if ($this->facetConfig == null) {
+	// 		$facetConfig = [];
+	// 		$author = new LibraryFacetSetting();
+	// 		$author->id = 1;
+	// 		$author->multiSelect = true;
+	// 		if ($listObject->displayListAuthor == 1) {
+	// 		$author->facetName = "author_display";
+	// 		}
+	// 		$author->displayName = "Created By";
+	// 		$author->numEntriesToShowByDefault = 5;
+	// 		$author->translate = true;
+	// 		$author->collapseByDefault = false;
+	// 		$author->useMoreFacetPopup = true;
+	// 		$facetConfig["author_display"] = $author;
+	// 		$this->facetConfig = $facetConfig;
+	// 	}
+	// 	return $this->facetConfig;
+	// }
+
+	public function getFacetConfig() {
+		require_once ROOT_DIR . '/RecordDrivers/ListsRecordDriver.php';
+
+		if ($this->facetConfig == null) {
+			$facetConfig = [ ];
+
+			$authorSettings = $this->getAuthorFacetSettings();
+
+			if ($authorSettings['enabled']) {
+				$author = new LibraryFacetSetting();
+				$author->id = $authorSettings['id'];
+				$author->multiSelect = $authorSettings['multiSelect'];
+				$author->facetName = $authorSettings['facetName'];
+				$author->displayName = $authorSettings['displayName'];
+				$author->numEntriesToShowByDefault = $authorSettings['numEntriesToShowByDefault'];
+				$author->translate = $authorSettings['translate'];
+				$author->collapseByDefault = $authorSettings['collapseByDefault'];
+				$author->useMoreFacetPopup = $authorSettings['useMoreFacetPopup'];
+				$author->facetCount = $authorSettings['facetCount'];
+				$facetConfig[$authorSettings['facetName']] = $author;
+			}
 			$this->facetConfig = $facetConfig;
 		}
 		return $this->facetConfig;
+	}
+
+	public function getAuthorFacetSettings() {
+		require_once ROOT_DIR . '/sys/UserLists/UserList.php';
+		require_once ROOT_DIR . '/RecordDrivers/ListsRecordDriver.php';
+
+
+		return [
+			'enabled' => true,
+			'id' => 1,
+			'multiSelect' => true,
+			'facetName' =>'author_display',
+			'displayName' => 'Created By',
+			'numEntriesToShowByDefault' => 5,
+			'translate' => true,
+			'collapseByDefault' => false,
+			'useMoreFacetPopup' => true,
+			'facetCount' => $listObject->displayListAuthor == 1 ? true : false,
+		];
 	}
 
 	public function getEngineName() {

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -12,6 +12,7 @@ class UserList extends DataObject {
 	public $created;
 	public $public;
 	public $searchable;
+	public $displayListAuthor;
 	public $deleted;
 	public $dateUpdated;
 	public $defaultSort;
@@ -50,6 +51,7 @@ class UserList extends DataObject {
 			'public',
 			'deleted',
 			'searchable',
+			'displayListAuthor',
 		];
 	}
 
@@ -124,6 +126,7 @@ class UserList extends DataObject {
 		}
 		if ($this->public == 0) {
 			$this->searchable = 0;
+			$this->displayListAuthor = 0;
 		}
 		global $memCache;
 		$memCache->delete('user_list_data_' . UserAccount::getActiveUserId());
@@ -136,6 +139,7 @@ class UserList extends DataObject {
 		}
 		if ($this->public == 0) {
 			$this->searchable = 0;
+			$this->displayListAuthor = 0;
 		}
 		$this->dateUpdated = time();
 		$result = parent::update();

--- a/install/aspen.sql
+++ b/install/aspen.sql
@@ -5354,6 +5354,7 @@ CREATE TABLE `user_list` (
   `created` int(11) DEFAULT NULL,
   `defaultSort` varchar(20) COLLATE utf8mb4_general_ci DEFAULT NULL,
   `searchable` tinyint(1) DEFAULT '0',
+  `displayListAuthor` tinyint(1) DEFAULT '0',
   `importedFrom` varchar(20) COLLATE utf8mb4_general_ci DEFAULT NULL,
   `nytListModified` varchar(20) COLLATE utf8mb4_general_ci DEFAULT NULL,
   PRIMARY KEY (`id`),


### PR DESCRIPTION
Some librarians would prefer not to share their name on public lists they have created. 
This patch adds the option for users to select whether to display or hide their username when they create a new list and to edit this setting on previously made lists. If the user chooses to hide their name, the "Created By" on the list results page will display "Anonymous."
Test Plan:
1) Sign into Aspen and create a list. Note that there is currently no option to hide your name. Ensure the list you create is public and searchable. 
2) Add at least 3 items to your list so that it will display in the search results. 
3) Search "Lists" and note that your list will appear and your username will be displayed next to the "Created By" tag. 
4) Apply patch
5) Create two new lists note that you now have the ability to decide whether to display your name or not. Ensure both lists are public and searchable. Enable "display list author" on one list and not on the other one. 
6) Add at least three items to each list. 
7) Search lists again and note that your username will appear on the list for which "display list author" is enabled, but on the list for which it is disabled, your name should not appear, you should see, "Created By: Anonymous."
8) Navigate to your account and then to your lists. Select a list and click "edit."
9) One of the options displayed should be to enable or disable the "display list author" function. 
10) Adjust this setting on one of your lists and again search lists. 
11) Note that the "Created By" row should reflect your new selection, displaying either your username or "Anonymous."
