### PR TITLE
Refactor: Move display and language options to burger menu

### DIFF
--- a/code/web/interface/themes/responsive/css/layout.less
+++ b/code/web/interface/themes/responsive/css/layout.less
@@ -167,19 +167,25 @@ hr.menu{
   cursor: pointer;
 }
 
-#aspenLanguagesMenuSection {
+#aspenLanguagesMenuSection,
+#aspenDisplayMenuSection {
   font-weight: bold;
   margin-top: 1em;
 }
 
-.header-menu-option.languageSelect {
-  margin-left: 2em;
+.header-menu-option.languageSelect,
+.header-menu-option.themeSelect {
+  margin-left: 3em;
 }
 
-.header-menu-option.languageSelected {
-  margin-left: .5em;
+.header-menu-option.languageSelected,
+.header-menu-option.themeSelected {
+  margin-left: 1em;
 }
-
+.header-menu-option.languageSelected i,
+.header-menu-option.themeSelected i{
+  margin-left: 0.5em;
+} 
 #library-name-header{
   font-size: @library-display-name-font-size;
   color: @library-display-name-color;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -8040,16 +8040,23 @@ hr.menu {
   margin-bottom: 3px;
   cursor: pointer;
 }
-#aspenLanguagesMenuSection {
+#aspenLanguagesMenuSection,
+#aspenDisplayMenuSection {
   font-weight: bold;
   margin-top: 1em;
 }
-.header-menu-option.languageSelect {
-  margin-left: 2em;
-}
-.header-menu-option.languageSelected {
+ .header-menu-option.languageSelect,
+.header-menu-option.themeSelect {
+ margin-left: 3em;
+} 
+.header-menu-option.languageSelected,
+.header-menu-option.themeSelected {
+  margin-left: 1em;
+} 
+.header-menu-option.languageSelected i,
+.header-menu-option.themeSelected i{
   margin-left: 0.5em;
-}
+} 
 #library-name-header {
   font-size: 26px;
   color: #8b8b8b;

--- a/code/web/interface/themes/responsive/header-menu.tpl
+++ b/code/web/interface/themes/responsive/header-menu.tpl
@@ -96,14 +96,19 @@
 		{/foreach}
 	{/if}
 
-	{if count($validLanguages) > 1}
-		<div class="header-menu-section" id="aspenLanguagesMenuSection">
-			<i class="fas fa-globe fa-fw"></i>{translate text="Language" isPublicFacing=true}
-		</div>
-
+	{if !empty($validLanguages)}
+		{if count($validLanguages) > 1}
+			<div class="header-menu-section" id="aspenLanguagesMenuSection">
+				<i class="fas fa-globe fa-fw"></i> {translate text="Languages" isPublicFacing=true}
+			</div>
+		{else}
+			<div class="header-menu-section" id="aspenLanguagesMenuSection">
+				<i class="fas fa-globe fa-fw"></i> {translate text="Language" isPublicFacing=true}
+			</div>
+		{/if}
 		{foreach from=$validLanguages key=languageCode item=language}
 			{if $userLang->code!=$languageCode}
-			<a onclick="return AspenDiscovery.setLanguage('{$languageCode}')">
+				<a onclick="return AspenDiscovery.setLanguage('{$languageCode}')">
 			{/if}
 				<div class="header-menu-option languageSelect{if $userLang->code==$languageCode}ed{/if}">
 					{if $userLang->code==$languageCode}
@@ -117,6 +122,31 @@
 		{/foreach}
 	{/if}
 
+	{if !empty($allActiveThemes)}
+		{if count($allActiveThemes) > 1}
+			<div class="header-menu-section" id="aspenDisplayMenuSection">
+				<i class="fas fa-cog fa-fw"></i> {translate text="Display Options" isPublicFacing=true}
+			</div>
+		{else}
+			<div class="header-menu-section" id="aspenDisplayMenuSection">
+				<i class="fas fa-cog fa-fw"></i> {translate text="Display" isPublicFacing=true}
+			</div>
+		{/if}
+		{foreach from=$allActiveThemes key=themeId item=themeName}
+			{if $themeId != $activeThemeId}
+				<a onclick="return AspenDiscovery.setTheme('{$themeId}')">
+			{/if}
+		<div class="header-menu-option themeSelect{if $themeId == $activeThemeId}ed{/if}">
+			{if $themeId == $activeThemeId}
+				<i class="fas fa-check fa-fw"></i>&nbsp;
+			{/if}
+			{$themeName}
+		</div>
+			{if $themeId != $activeTheme}
+			</a>
+			{/if}
+		{/foreach}
+	{/if}
 	{if !empty($masqueradeMode)}
 		<a class="btn btn-default btn-sm btn-block" onclick="AspenDiscovery.Account.endMasquerade()">{translate text="End Masquerade" isAdminFacing=true}</a>
 	{/if}

--- a/code/web/interface/themes/responsive/header_responsive.tpl
+++ b/code/web/interface/themes/responsive/header_responsive.tpl
@@ -32,17 +32,7 @@
 			</a>
 		</div>
 	{/if}
-	{if count($validLanguages) > 1 || count($allActiveThemes) > 1}
 		<div id="language-selection-header" class="col-tn-12 col-xs-4 col-sm-4 col-md-4 col-lg-4 pull-right">
-			<a id="theme-selection-dropdown" class="btn btn-default btn-sm" {if !empty($loggedIn)}href="/MyAccount/MyPreferences" {else} onclick="AspenDiscovery.showDisplaySettings()"{/if}>
-				{if count($validLanguages) > 1 && count($allActiveThemes) > 1}
-					{translate text="Languages & Display" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
-				{elseif count($validLanguages) > 1}
-					{translate text="Languages" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
-				{else}
-					{translate text="Display" isPublicFacing=true}&nbsp;<i class="fa fa-cog"></i>
-				{/if}
-			</a>
 			{if count($validLanguages) > 1}
 				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
 					<div id="translationMode" style="padding-top:.5em">
@@ -55,68 +45,4 @@
 				{/if}
 			{/if}
 		</div>
-		<div style="display: none">
-		<div id="language-selection-header" class="col-tn-12 col-xs-4 col-sm-4 col-md-4 col-lg-4 pull-right">
-			{if count($validLanguages) == 2}
-				<div class="btn-group btn-group-sm" role="group">
-				{foreach from=$validLanguages key=languageCode item=language}
-					<div class="availableLanguage btn btn-sm btn-default {if $userLang->code==$languageCode}active{/if}">
-					{if $userLang->code!=$languageCode}
-					<a onclick="return AspenDiscovery.setLanguage('{$languageCode}')" role="button">
-					{/if}
-						<div>
-							{$language->displayName}
-						</div>
-					{if $userLang->code!=$languageCode}
-					</a>
-					{/if}
-					</div>
-				{/foreach}
-				</div>
-				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
-					<div id="translationMode" style="padding-top:.5em">
-						{if !empty($translationModeActive)}
-							<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
-						{else}
-							<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
-						{/if}
-					</div>
-				{/if}
-			{elseif count($validLanguages) >= 3}
-				<div class="dropdown">
-					<button class="btn btn-default btn-sm dropdown-toggle" type="button" id="language-selection-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{translate text="Languages" isPublicFacing=true}&nbsp;<span class="caret"></span>
-					</button>
-					<ul id="select-language" class="dropdown-menu" aria-labelledby="language-selection-dropdown">
-						{foreach from=$validLanguages key=languageCode item=language}
-							<li><a onclick="return AspenDiscovery.setLanguage('{$languageCode}')">{$language->displayName}</a></li>
-						{/foreach}
-					</ul>
-				</div>
-
-				{if !empty($loggedIn) && in_array('Translate Aspen', $userPermissions)}
-					<div id="translationMode">
-						{if !empty($translationModeActive)}
-							<a onclick="return AspenDiscovery.changeTranslationMode(false)" class="btn btn-primary btn-xs active" role="button">{translate text="Exit Translation Mode" isPublicFacing=true}</a>
-						{else}
-							<a onclick="return AspenDiscovery.changeTranslationMode(true)" class="btn btn-primary btn-xs" role="button">{translate text="Start Translation Mode" isPublicFacing=true}</a>
-						{/if}
-					</div>
-				{/if}
-			{/if}
-			{if count($allActiveThemes) > 1}
-				<div class="dropdown">
-					<button class="btn btn-default btn-sm dropdown-toggle" type="button" id="theme-selection-dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-						{translate text="Display" isPublicFacing=true}&nbsp;<span class="caret"></span>
-					</button>
-					<ul id="select-theme" class="dropdown-menu" aria-labelledby="theme-selection-dropdown">
-						{foreach from=$allActiveThemes key=themeId item=themeName}
-							<li><a onclick="return AspenDiscovery.setTheme('{$themeId}')">{$themeName}</a></li>
-						{/foreach}
-					</ul>
-				</div>
-			{/if}
-		</div>
-		</div>
-	{/if}
 {/strip}


### PR DESCRIPTION
The burger menu now contains a section for languages, which displays all languages currently active on the user's account and a section for displays to reflect the themes available. This supports accessibility and creates continuity between the display whether logged in or not.
To Test:
1)Prior to implementation, if not logged in you should see a button in the header that will read "Languages and Display" or "Languages". When clicked, a modal opens up so that you can make your selection.
2)Log in and note that to change the language, you need to use the burger menu. Click on an available language and note that you are taken to a preferences page.
3)Implement new code and note that you are not shown the "Languages and Display" button, regardless of whether you are logged in or not.
4)Use the burger menu to select an available language and note that the language can now be selected directly from the menu, the page should not redirect you, but alter the display so that it is now in your chosen language.