### PR TITLE
Refactor: Adjust availability tabs in mobile browsing

### DIFF
--- a/code/web/interface/themes/responsive/css-rtl/main.css
+++ b/code/web/interface/themes/responsive/css-rtl/main.css
@@ -10202,10 +10202,24 @@ a.browse-thumbnail.active {
   }
   #availabilityControl button {
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
+    font-size: 10px;
+    line-height: 1.2;
     border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 .search-results-navigation {
   display: flex;

--- a/code/web/interface/themes/responsive/css-rtl/results-list.less
+++ b/code/web/interface/themes/responsive/css-rtl/results-list.less
@@ -289,11 +289,28 @@
     padding-left: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+    padding: 5px 10px;
+    font-size: 10px;
+    line-height: 1.2;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
   //.title-rating {
   //  display: none;
   //}
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 
 //// Hide Formats label when shown in modal pop-up

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -2,6 +2,7 @@
 @import "lib/rome.min.css";
 @import "simplemde.min.css";
 @import "lib/Chart.min.css";
+@import "variables.less";
 article,
 aside,
 details,
@@ -10353,10 +10354,24 @@ a.browse-thumbnail.active {
   }
   #availabilityControl button {
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
+    font-size: 10px;
+    line-height: 1.2;
     border-radius: 3px;
-  }
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
+    }
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 .search-results-navigation {
   display: flex;

--- a/code/web/interface/themes/responsive/css/results-list.less
+++ b/code/web/interface/themes/responsive/css/results-list.less
@@ -289,11 +289,28 @@
     padding-right: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+    padding: 5px 10px;
+    font-size: 10px;
+    line-height: 1.2;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
   //.title-rating {
   //  display: none;
   //}
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 
 //// Hide Formats label when shown in modal pop-up


### PR DESCRIPTION
TEST PLAN

1) Carry out a search that produces multiple results. 
2) Resize the screen and note that at some widths, the 'Entire Collection' tab is significantly taller than the 'Centerville' and 'Available Now' tabs. 
3) APPLY PATCH
4) Resize the screen again. At all mobile widths, the availability tabs should be consistent with each other. 