### PR TITLE
Refactor: Added downward arrow to formats in grouped results

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/result.tpl
@@ -211,12 +211,12 @@
 							{translate text="Formats" isPublicFacing=true}
 						</div>
 						<div class="hidethisdiv{$summId|escape} result-value col-sm-8 col-xs-12">
-							<a onclick="$('#relatedManifestationsValue{$summId|escape},.hidethisdiv{$summId|escape}').toggleClass('hidden-xs');return false;" role="button">
+							<a onclick="$('#relatedManifestationsValue{$summId|escape}').toggleClass('hidden-xs');return false;" role="button">
 								{implode subject=$relatedManifestations|@array_keys glue=", "}
+									&nbsp;<i class="fas fa-angle-down"></i>			
 							</a>
 						</div>
 					{/if}
-
 				</div>
 
 				{* Formats Section *}


### PR DESCRIPTION
TEST PLAN:
1) Carry out a search that returns grouped results. 
2) Note that on mobile views, in order to see the various formats available, you must click on the formats e.g. books, music etc. 
3) When you click it again, the formats section should close. 
4) Some patrons have found it difficult to identify the formats as the place to click in order to view the formats. 
5)APPLY THE PATCH
6) Repeat the steps above. 
7) Note that there is now an arrow next to the list of available formats to highlight where to click in order to see the format list. It has the same functionality as clicking on the rest of the format list. 