### PR TITLE
fix: disable any OPACUserCSS from koha (self-reg)

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -270,7 +270,7 @@ class Koha extends AbstractIlsDriver {
 				$loginResult = $this->loginToKohaOpac($patron);
 				if ($loginResult['success']) {
 
-					$updatePage = $this->getKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl');
+					$updatePage = $this->getKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl?DISABLE_SYSPREF_OPACUserCSS=1');
 					//Get the csr token
 					$csr_token = '';
 					if (preg_match('%<input type="hidden" name="csrf_token" value="(.*?)" />%s', $updatePage, $matches)) {
@@ -346,7 +346,7 @@ class Koha extends AbstractIlsDriver {
 						$postVariables['resendEmail'] = strip_tags($_REQUEST['resendEmail']);
 					}
 
-					$postResults = $this->postToKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl', $postVariables);
+					$postResults = $this->postToKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl?DISABLE_SYSPREF_OPACUserCSS=1', $postVariables);
 
 					$messageInformation = [];
 					if (preg_match('%<div class="alert alert-warning">(.*?)</div>%s', $postResults, $messageInformation)) {
@@ -4340,7 +4340,7 @@ class Koha extends AbstractIlsDriver {
 
 		if ($this->getKohaVersion() < 20.05) {
 			$catalogUrl = $this->accountProfile->vendorOpacUrl;
-			$selfRegPage = $this->getKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl');
+			$selfRegPage = $this->getKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl?DISABLE_SYSPREF_OPACUserCSS=1');
 			$captcha = '';
 			$captchaDigest = '';
 			$captchaInfo = [];
@@ -4404,7 +4404,7 @@ class Koha extends AbstractIlsDriver {
 			$postFields['action'] = 'create';
 			$headers = ['Content-Type: application/x-www-form-urlencoded'];
 			$this->opacCurlWrapper->addCustomHeaders($headers, false);
-			$selfRegPageResponse = $this->postToKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl', $postFields);
+			$selfRegPageResponse = $this->postToKohaPage($catalogUrl . '/cgi-bin/koha/opac-memberentry.pl?DISABLE_SYSPREF_OPACUserCSS=1', $postFields);
 
 			$matches = [];
 			if (preg_match('%<h1>Registration Complete!</h1>.*?<span id="patron-userid">(.*?)</span>.*?<span id="patron-password">(.*?)</span>.*?<span id="patron-cardnumber">(.*?)</span>%s', $selfRegPageResponse, $matches)) {


### PR DESCRIPTION
If a library has previously used the koha opac before switching to Aspen and have CSS customisations, these can interfere with some of the page scraping in Aspen and cause things to malfunction

This patch adds the optional flag to remove any css customisations on page load to the urls used in the web scraping process for self-reg

Test Plan:
Set up oauth api keys in koha (give user superlibrarian perms) 
add api keys to aspen DB 
  - docker exec -it aspen-db /bin/bash 
  - mysql -uroot -paspen aspen
  -update account_profiles set oAuthClientId = '*****', oAuthClientSecret = '****' where id=2;
Set up self reg in Koha and Aspen
apply patch
check self reg still works correctly