### PR TITLE
fix: add vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ sites/default/solr-7.6.0/logs/*
 sites/default/solr-7.6.0/server/logs/*
 sites/default/solr-7.6.0/server/tmp/*
 install/templates/*
+.vscode
 
 # Compiled source #                                                                                   
 ###################


### PR DESCRIPTION
This patch stops the .vscode folder from being added to git source control.

This probably does not need testing, trivial.