### PR TITLE
fix: update href in sso-login.tpl to new saml auth

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/sso-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/sso-login.tpl
@@ -49,7 +49,7 @@
 				{translate text="Sign in With %1%" 1=$samlBtnLabel isPublicFacing=true}
 			</a>
 		{else}
-			<a href="/saml2auth.php?samlLogin=y&idp={$samlEntityId}" class="btn btn-default btn-lg" style="background-color: {$samlBtnBgColor}; color: {$samlBtnTextColor}">
+			<a href="/Authentication/SAML2?init" class="btn btn-default btn-lg" style="background-color: {$samlBtnBgColor}; color: {$samlBtnTextColor}">
 				{translate text="Sign in with %1%" 1=$samlBtnLabel isPublicFacing=true}
 			</a>
 		{/if}


### PR DESCRIPTION
In d6f3c3e4c the hrefs for SSO were updated for one portion of the if statement in sso-login but it appears may have been missed in the else statement below

This patch amends the hrefs to match (as the ones there previously no longer work)

Previously tested with the tech team. Could be challenging to test locally, maybe skip as fix is trivial?