### PR TITLE
FEAT: Allow Summon to be included in Combined Results

### DIFF
--- a/code/web/sys/LibraryLocation/CombinedResultSection.php
+++ b/code/web/sys/LibraryLocation/CombinedResultSection.php
@@ -24,6 +24,9 @@ abstract class CombinedResultSection extends DataObject {
 		} elseif (array_key_exists('EBSCOhost', $enabledModules) && $library->edsSettingsId == -1) {
 			$validResultSources['ebscohost'] = 'EBSCOhost';
 		}
+		if (array_key_exists('Summon', $enabledModules) && $library->summonSettingsId != -1) {
+			$validResultSources['summon'] = 'Summon';
+		}
 		if (array_key_exists('Events', $enabledModules)) {
 			$validResultSources['events'] = 'Events';
 		}
@@ -88,6 +91,8 @@ abstract class CombinedResultSection extends DataObject {
 			return "/Search/Results?lookfor=$searchTerm&searchSource=local";
 		} elseif ($this->source == 'dpla') {
 			return "https://dp.la/search?q=$searchTerm";
+		} elseif ($this->source == 'summon') {
+			return "Search/Results?lookfor=$searchTerm&searchSource=summon";
 		} elseif ($this->source == 'ebsco_eds') {
 			return "/EBSCO/Results?lookfor=$searchTerm&searchSource=ebsco_eds";
 		} elseif ($this->source == 'ebscohost') {


### PR DESCRIPTION
Test Plan:
1. Log in to Aspen as an administrator. 
2. Ensure that the Summon module is set up and all relevant credentials have been added to the settings.
3. Navigate to the 'Primary Configuration' section in the admin menu section and select 'Library Systems.'
4. Select the option to edit your chosen library.
5. Scroll down to the 'Combined Results' section.
6. Enable combined results and click 'Add New' in the combined results section.
7. Add 'Summon' and another option and save
8. Use the search bar to carry out a search, selecting 'Combined Results' in the dropdown. 
9. Your results should return in two columns, one for your Summon results and one for your other selection
NOTE: Addition of section headings possibly required