### PR TITLE
Fix: prevented an error occurring when a Summon filter contains '&'

### DIFF
--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -481,22 +481,21 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 
 	//Compile filter options chosen in side facets and add to filter array to be passed in via options array
 	public function getSummonFilters() {
-        $this->filters = array();
-        foreach($this->filterList as $key => $value) {
-            if(is_array($value)) {
-                foreach($value as $val){
-                    $parts = explode(' ', $val);
-                    $result = implode('+', $parts);
-                    $this->filters[] = urlencode($key . ',') . $result . urlencode(',');
-                }
-            } else {
-                $parts = explode(' ', $value);
-                $result = implode('+', $parts);
-                $this->filters = urlencode($key . ',') . $result . urlencode(',');
-            }
-        }
-      return $this->filters;
-    }	
+		$this->filters = array();
+		foreach ($this->filterList as $key => $value) {
+			if (is_array($value)) {
+				foreach ($value as $val) {
+					$encodedValue = urlencode($val); 
+					$this->filters[] = urlencode($key) . ',' . $encodedValue . ','; 
+				}
+			} else {
+				$encodedValue = urlencode($value); 
+				$this->filters[] = urlencode($key) . ',' . $encodedValue . ','; 
+			}
+		}
+		return $this->filters;
+	}
+	
 	
 	/**
 	 * Generate an HMAC hash for authentication


### PR DESCRIPTION


This patch alters the order and concatenation of Summon filters so that Summon filters that contain an ampersand return a result rather than an error.
Test Plan:
1. Set up Summon as usual on Aspen. 
2. Carry out a search, ensuring that the dropdown is set to 'Articles & Databases.'
3.  In one of the side facets, select a filter than contains an ampersand. 
4. When the page loads, you will be presented with an authentication error. 
5. Apply the patch and repeat the process above.
6. When you use a filter than contains an ampersand, you should now be presented with relevant search results and no authentication error. 