### PR TITLE
Cookie consent snippets

### DIFF
--- a/code/web/release_notes/24.05.00.MD
+++ b/code/web/release_notes/24.05.00.MD
@@ -120,7 +120,7 @@
 //Jacob
 ### Data Protection Updates
 - Fixed issue where Cookie Consent banner would not disappear while not logged in, regardless of cookie preferences. (JOM)
-
+- Added the ability to only apply JS-Snippets if cookie consent is given while "Require Cookie Consent" is enabled. (JOM)
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/sys/DBMaintenance/version_updates/24.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.05.00.php
@@ -82,6 +82,15 @@ function getUpdates24_05_00(): array {
 			]
 		]
 		//other
+		//jacob - PTFS Europe
+		'Snippet_Contains_Analytics_Cookies' => [
+			 'title' => 'JS Snippet Contains Analytics Cookies',
+			 'description' => 'Add a toggle for if a JS snippet contains analytics cookies or not.',
+			 'continueOnError' => true,
+			 'sql' => [
+				 'ALTER TABLE javascript_snippets ADD COLUMN containsAnalyticsCookies TINYINT(1)'
+			 ]
+		 ], //Snippet_Contains_Marketing_Cookies
 
 
 	];

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -535,6 +535,18 @@ class UInterface extends Smarty {
 		$customJavascript = '';
 		if (!isset($_REQUEST['noCustomJavaScript']) && !isset($_REQUEST['noCustom'])) {
 			try {
+				if (isset($_COOKIE["cookieConsent"])) {
+					$cookie = json_decode(urldecode($_COOKIE["cookieConsent"]), true);
+					if ($cookie != null) {
+						$analyticsPref = $cookie['Analytics'];
+					}else{
+						$analyticsPref = 0;
+					}
+				}else{
+					$cookie = null;
+					$analyticsPref = 0;
+				}
+
 				if (isset($location)) {
 					require_once ROOT_DIR . '/sys/LocalEnrichment/JavaScriptSnippetLocation.php';
 					$javascriptSnippetLocation = new JavaScriptSnippetLocation();
@@ -545,10 +557,15 @@ class UInterface extends Smarty {
 						$javascriptSnippet = new JavaScriptSnippet();
 						$javascriptSnippet->id = $javascriptSnippetLocation->javascriptSnippetId;
 						if ($javascriptSnippet->find(true)) {
-							if (strlen($customJavascript) > 0) {
-								$customJavascript .= "\n";
+							if (empty($library->cookieStorageConsent) ||
+								(!empty($library->cookieStorageConsent) && empty($javascriptSnippet->containsAnalyticsCookies)) ||
+								(!empty($library->cookieStorageConsent) && !empty($javascriptSnippet->containsAnalyticsCookies) && $analyticsPref == 1)
+							) {
+								if (strlen($customJavascript) > 0) {
+									$customJavascript .= "\n";
+								}
+								$customJavascript .= trim($javascriptSnippet->snippet);
 							}
-							$customJavascript .= trim($javascriptSnippet->snippet);
 						}
 					}
 				} else {
@@ -561,10 +578,15 @@ class UInterface extends Smarty {
 						$javascriptSnippet = new JavaScriptSnippet();
 						$javascriptSnippet->id = $javascriptSnippetLibrary->javascriptSnippetId;
 						if ($javascriptSnippet->find(true)) {
-							if (strlen($customJavascript) > 0) {
-								$customJavascript .= "\n";
+							if (empty($library->cookieStorageConsent) ||
+								(!empty($library->cookieStorageConsent) && empty($javascriptSnippet->containsAnalyticsCookies)) ||
+								(!empty($library->cookieStorageConsent) && !empty($javascriptSnippet->containsAnalyticsCookies) && $analyticsPref == 1)
+							) {
+								if (strlen($customJavascript) > 0) {
+									$customJavascript .= "\n";
+								}
+								$customJavascript .= trim($javascriptSnippet->snippet);
 							}
-							$customJavascript .= trim($javascriptSnippet->snippet);
 						}
 					}
 				}

--- a/code/web/sys/LocalEnrichment/JavaScriptSnippet.php
+++ b/code/web/sys/LocalEnrichment/JavaScriptSnippet.php
@@ -9,6 +9,7 @@ class JavaScriptSnippet extends DB_LibraryLocationLinkedObject {
 	public $id;
 	public $name;
 	public $snippet;
+	public $containsAnalyticsCookies;
 
 	protected $_libraries;
 	protected $_locations;
@@ -56,6 +57,13 @@ class JavaScriptSnippet extends DB_LibraryLocationLinkedObject {
 				'description' => 'Define locations that use this snippet',
 				'values' => $locationList,
 				'hideInLists' => true,
+			],
+
+			'containsAnalyticsCookies' => [
+				'property' => 'containsAnalyticsCookies',
+				'type' => 'checkbox',
+				'label' => 'Contains Analytics Cookies',
+				'description' => 'This snippet contains analytics cookies',
 			],
 		];
 	}


### PR DESCRIPTION
This patch adds the ability to flag a JavaScript snippet as containing analytics cookies or not and then runs/does not run the snippet accordingly. 

To Test:

- Navigate to JavaScript snippets and add a snippet to test is running/not running
- Notice the new option for if snippet contains Analytics cookies.
- Check that the snippet runs as expected.
- Navigate to Library systems and enable cookie consent 
- Check that snippet runs if "contains Analytics cookies" is disabled and does not if "contains Analytics cookies" is enabled
- Accept all cookies.
- Snippet should always run regardless of "contains Analytics cookies" 
- Go to  my preferences and disable consent for Analytics cookies.
- Check that snippet runs if "contains Analytics cookies" is disabled and does not if "contains Analytics cookies" is enabled
