### PR TITLE
Social media links granularity

### DIFF
--- a/code/web/interface/themes/responsive/EBSCO/share-tools.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/share-tools.tpl
@@ -5,13 +5,16 @@
 		{if $showEmailThis == 1}
 		{/if}
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share on Facebook" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}"  aria-label="{translate text="Pin on Pinterest" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/EBSCOhost/share-tools.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/share-tools.tpl
@@ -5,13 +5,16 @@
 		{if $showEmailThis == 1}
 		{/if}
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share on Facebook" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Pin on Pinterest" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Events/share-tools.tpl
+++ b/code/web/interface/themes/responsive/Events/share-tools.tpl
@@ -3,13 +3,16 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-		<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$eventUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true}" aria-label="{translate text="Share on Facebook" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$eventUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true}" aria-label="Share on Facebook">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$eventUrl}&media={$recordDriver->getBookcoverUrl('large', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Pin on Pinterest" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$eventUrl}&media={$recordDriver->getBookcoverUrl('large', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Genealogy/share-tools.tpl
+++ b/code/web/interface/themes/responsive/Genealogy/share-tools.tpl
@@ -3,13 +3,16 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share on Facebook" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Pin on Pinterest" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/share-tools.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/share-tools.tpl
@@ -8,16 +8,21 @@
 			</a>
 		{/if}
 		{if !empty($showShareOnExternalSites)}
-			<a href="https://twitter.com/intent/tweet?text={$recordDriver->getTitle()|urlencode}+{$url}/GroupedWork/{$recordDriver->getPermanentId()}/Home" target="_blank" title="{translate text="Share on Twitter" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share on Twitter" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkTwitter)}
+			<a href="https://twitter.com/intent/tweet?text={$recordDriver->getTitle()|urlencode}+{$url}/GroupedWork/{$recordDriver->getPermanentId()}/Home" target="_blank" title="{translate text="Share on Twitter" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-twitter-square fa-2x fa-fw"></i>
 			</a>
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share %1%, by %2% on Facebook" 1=$recordDriver->getTitle()|escapeCSS 2=$recordDriver->getTitle()|escapeCSS inAttribute=true isPublicFacing=true translateParameters=false} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$recordDriver->getLinkUrl()|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true}" aria-label="Share {$recordDriver->getTitle()|escapeCSS}, by {$recordDriver->getPrimaryAuthor()|escape} on Facebook">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Pin %1%, by %2% on Pinterest" 1=$recordDriver->getTitle()|escapeCSS 2=$recordDriver->getTitle()|escapeCSS inAttribute=true isPublicFacing=true translateParameters=false} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$url}/{$recordDriver->getLinkUrl()}&media={$url}{$recordDriver->getBookcoverUrl('large')}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true}" aria-label="Pin {$recordDriver->getTitle()|escapeCSS}, by {$recordDriver->getPrimaryAuthor()|escape} on Pinterest">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Lists/share-tools.tpl
+++ b/code/web/interface/themes/responsive/Lists/share-tools.tpl
@@ -3,13 +3,16 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$recordUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Share on Facebook" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$recordUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$recordUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text="Pin on Pinterest" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$recordUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/OpenArchives/share-tools.tpl
+++ b/code/web/interface/themes/responsive/OpenArchives/share-tools.tpl
@@ -3,13 +3,16 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$openArchiveUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}"  aria-label="{translate text='Share on Facebook' isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$openArchiveUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$openArchiveUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}"  aria-label="{translate text='Pin on Pinterest' isPublicFacing=true inAttribute=true} ({translate text='opens in new window' isPublicFacing=true inAttribute=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$openArchiveUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/interface/themes/responsive/Websites/share-tools.tpl
+++ b/code/web/interface/themes/responsive/Websites/share-tools.tpl
@@ -3,13 +3,16 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$pageUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}" aria-label="{translate text='Share on Facebook' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">
+			{if !empty($sharerLinkFacebook)}
+			<a href="http://www.facebook.com/sharer/sharer.php?u={$pageUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
-
-			<a href="http://www.pinterest.com/pin/create/button/?url={$pageUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}" aria-label="{translate text='Pin on Pinterest' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">
+			{/if}
+			{if !empty($sharerLinkPinterest)}
+			<a href="http://www.pinterest.com/pin/create/button/?url={$pageUrl}&media={$recordDriver->getBookcoverUrl('medium', true)}&description=Pin%20on%20Pinterest" target="_blank" title="{translate text="Pin on Pinterest" inAttribute=true isPublicFacing=true}">
 				<i class="fab fa-pinterest-square fa-2x fa-fw"></i>
 			</a>
+			{/if}
 		{/if}
 	</div>
 	{/if}

--- a/code/web/release_notes/24.05.00.MD
+++ b/code/web/release_notes/24.05.00.MD
@@ -121,6 +121,9 @@
 ### Data Protection Updates
 - Fixed issue where Cookie Consent banner would not disappear while not logged in, regardless of cookie preferences. (JOM)
 
+### Other Updates
+- Allow individual sharer links to be enabled/disabled granularly. (*JOM*)
+
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/sys/DBMaintenance/version_updates/24.05.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.05.00.php
@@ -80,8 +80,19 @@ function getUpdates24_05_00(): array {
 			'sql' => [
 				'ALTER TABLE library ADD COLUMN allowMasqueradeWithUsername TINYINT NOT NULL DEFAULT 1',
 			]
-		]
+		],
 		//other
+		//jacob - PTFS Europe
+		'granularShareLinks' => [
+			'title' => 'Ability to enable/disable share links per external share site',
+			'description' => 'Add the ability to enable/disable the sharing links for individual lites  (facebook/twitter etc.)',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN sharerLinkFacebook TINYINT(1) DEFAULT 1',
+				'ALTER TABLE library ADD COLUMN sharerLinkPinterest TINYINT(1) DEFAULT 1',
+				'ALTER TABLE library ADD COLUMN sharerLinkTwitter TINYINT(1) DEFAULT 1',
+			]
+		],
 
 
 	];

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -643,6 +643,9 @@ class UInterface extends Smarty {
 			$this->assign('showEmailThis', $location->showEmailThis && $library->showEmailThis);
 			$showStaffView = $groupedWorkDisplaySettings->showStaffView;
 			$this->assign('showShareOnExternalSites', $location->showShareOnExternalSites && $library->showShareOnExternalSites);
+			$this->assign('sharerLinkTwitter', $library->sharerLinkTwitter);
+			$this->assign('sharerLinkFacebook', $library->sharerLinkFacebook);
+			$this->assign('sharerLinkPinterest', $library->sharerLinkPinterest);
 			$this->assign('showGoodReadsReviews', $groupedWorkDisplaySettings->showGoodReadsReviews);
 			$showHoldButton = (($location->showHoldButton == 1) && ($library->showHoldButton == 1)) ? 1 : 0;
 			$showHoldButtonInSearchResults = (($location->showHoldButton == 1) && ($library->showHoldButtonInSearchResults == 1)) ? 1 : 0;
@@ -659,6 +662,9 @@ class UInterface extends Smarty {
 			$this->assign('showComments', $groupedWorkDisplaySettings->showComments);
 			$this->assign('showEmailThis', $library->showEmailThis);
 			$this->assign('showShareOnExternalSites', $library->showShareOnExternalSites);
+			$this->assign('sharerLinkTwitter', $library->sharerLinkTwitter);
+			$this->assign('sharerLinkFacebook', $library->sharerLinkFacebook);
+			$this->assign('sharerLinkPinterest', $library->sharerLinkPinterest);
 			$showStaffView = $library->getGroupedWorkDisplaySettings()->showStaffView;
 			$this->assign('showSimilarTitles', $groupedWorkDisplaySettings->showSimilarTitles);
 			$this->assign('showSimilarAuthors', $groupedWorkDisplaySettings->showSimilarAuthors);

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -265,6 +265,9 @@ class Library extends DataObject {
 	public /** @noinspection PhpUnused */
 		$showLibraryHoursNoticeOnAccountPages;
 	public $showShareOnExternalSites;
+	public $sharerLinkFacebook;
+	public $sharerLinkPinterest;
+	public $sharerLinkTwitter;
 	public /** @noinspection PhpUnused */
 		$barcodePrefix;
 	public $libraryCardBarcodeStyle;
@@ -3068,6 +3071,39 @@ class Library extends DataObject {
 						'description' => 'Whether or not sharing on external sites (Twitter, Facebook, Pinterest, etc.) is shown',
 						'hideInLists' => true,
 						'default' => 1,
+					],
+					'sharerLinksSection' => [
+						'property' => 'sharerLinksSection',
+						'type' => 'section',
+						'label' => 'Share Links To Show',
+						'hideInLists' => true,
+						'permissions' =>['Library Catalog Options'],
+						'properties' => [
+							'sharerLinkTwitter' => [
+								'property' => 'sharerLinkTwitter',
+								'type' => 'checkbox',
+								'label' => 'Show Sharing Link To Twitter',
+								'description' => 'Whether or not sharing on Twitter is shown',
+								'hideInLists' => true,
+								'default' => 1,
+							],
+							'sharerLinkFacebook' => [
+								'property' => 'sharerLinkFacebook',
+								'type' => 'checkbox',
+								'label' => 'Show Sharing Link To Facebook',
+								'description' => 'Whether or not sharing on Facebook is shown',
+								'hideInLists' => true,
+								'default' => 1,
+							],
+							'sharerLinkPinterest' => [
+								'property' => 'sharerLinkPinterest',
+								'type' => 'checkbox',
+								'label' => 'Show Sharing Link To Pinterest',
+								'description' => 'Whether or not sharing on Pinterest is shown',
+								'hideInLists' => true,
+								'default' => 1,
+							],
+						],
 					],
 				],
 			],


### PR DESCRIPTION
This adds the option to choose which of the social media link will appear for your library system, rather than having all of them appear or not.

To Test:

Navigate to "aspen-administration -> library systems -> {edit default library}"
search for "shar" and enable "Show Sharing To External Sites" -> SAVE
Do a search and notice that share links appear under each result
Navigate to the above and search for "shar" again.
Test the check-boxes for "Show Sharing Link To {x}"
After modifying each, check that they appear/don't appear correctly upon a catalogue search.