### PR TITLE
feat: alter unsaved search deletion and add option for last used lists

### DIFF
--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -52,6 +52,14 @@
 - Added new Documentation links to several settings pages (*MKD*)
 - Updates to default user roles: removed testing roles and a couple uncommonly used roles; updated role titles (*MKD*)
 
+//alexander
+### New Settings
+- Added option to delete stored information for lastListUsed after 14 days. Primary Configuration > Library Systems. 
+
+### Database Cleanup Script Updates
+- Update DatabaseCleanup.java to delete unsaved searches each time the cron runs. 
+- Add function to remove last list used after 14 days for libraries who have selected this option. 
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -59,3 +67,6 @@
   - Kodi Lein (KL)
   - Liz Rea (LR)
   - Morgan Daigneault (MKD)
+
+- PTFS Europe
+  - Alexander Blanchard (AB)

--- a/code/web/sys/DBMaintenance/version_updates/24.06.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.06.00.php
@@ -64,6 +64,15 @@ function getUpdates24_06_00(): array {
 			],
 		], //full_text_limiter
 
+		//alexander - PTFS Europe
+		'library_delete_last_list_used_entries' => [
+			'title' => 'Library delete last list used history',
+			'description' => 'Add an option to delete lastListUsed',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE library ADD COLUMN deleteLastListUsedEntries TINYINT(1) DEFAULT 0',
+			],
+		],
 		//other
 
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -113,6 +113,7 @@ class Library extends DataObject {
 	public $showUserContactInformation;
 	public $inSystemPickupsOnly;
 	public $validPickupSystems;
+	public $deleteLastListUsedEntries;
 	/** @noinspection PhpUnused */
 	public $pTypes; //This is used as part of the indexing process
 	public $facetLabel;
@@ -2836,6 +2837,14 @@ class Library extends DataObject {
 						'description' => 'Which lists should be included in this scope',
 						'forcesListReindex' => true,
 						'default' => 4,
+					],
+					'deleteLastListUsedEntries' => [
+						'property' => 'deleteLastListUsedEntries',
+						'type' => 'checkbox',
+						'label' => 'Delete Last Used List After 14 Days',
+						'description' => 'Whether to delete the last used list information for users after 14 days',
+						'hideInLists' => true,
+						'default' => 0,
 					],
 					'allowAutomaticSearchReplacements' => [
 						'property' => 'allowAutomaticSearchReplacements',


### PR DESCRIPTION
This commit alters the deletion of unsaved searches to be carried out each time the cron script runs. It also adds the option for libraries to choose to have stored information about the last list a user has accessed deleted after 14 days.

Test Plan:
1. Apply the patch. 
2.  Navigate to Primary Configuration >  Library Systems. 
3.  Select your library and click to edit. 
4.  Use the search bar to find 'Delete last used list after 14 days' or locate this new option under the 'Searching' section. 
5. The box should be unchecked by default as this is an opt in option. 
6.  When checked, when the cron runs, information from the users table relating to their last list used will be deleted if it has not been updated for at least 14 days. 