### PR TITLE
Fix spotlight tabbed display and drop down list

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -74,6 +74,11 @@
 					{/if}
 				{/if}
 
+				{assign var="tabClasses" value="tab-pane" }
+				{if $active}
+					{assign var="tabClasses" value="$tabClasses active" }
+				{/if}
+
 				{if $collectionSpotlight->style == 'horizontal'}
 					{include file='CollectionSpotlight/titleScroller.tpl'}
 				{elseif $collectionSpotlight->style == 'horizontal-carousel'}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -185,10 +185,7 @@
 
 			$(document).ready(function(){ldelim}
 				{if count($collectionSpotlight->lists) > 1 && (!isset($collectionSpotlight->listDisplayType) || $collectionSpotlight->listDisplayType == 'tabs')}
-				var tablists = document.querySelectorAll('[role=tablist]');
-                for (var i = 0; i < tablists.length; i++) {ldelim}
-                    new TabsSwitcher(tablists[i]);
-                {rdelim}
+				applyTabsSwitcher();
 				$('#collectionSpotlight{$collectionSpotlight->id} a[data-toggle="tab"]').on('shown.bs.tab', function (e) {ldelim}
 					$('#collectionSpotlightCarousel' + $(e.target).data('carouselid')).jcarousel('reload');
 				{rdelim});
@@ -196,6 +193,14 @@
 			{rdelim});
 		</script>
 	{/if}
+	<script type="text/javascript">
+		function applyTabsSwitcher(){ldelim}
+			var tablists = document.querySelectorAll('[role=tablist]');
+			for (var i = 0; i < tablists.length; i++) {ldelim}
+				new TabsSwitcher(tablists[i]);
+			{rdelim}
+		{rdelim}
+	</script>
 	{strip}
 </div>
 {/strip}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -141,7 +141,7 @@
 				var selectedOption = availableLists.options[availableLists.selectedIndex];
 
 				var selectedList = selectedOption.value;
-				$("#collectionSpotlight{$collectionSpotlight->id} .titleScroller.active").removeClass('active').hide();
+				$("#collectionSpotlight{$collectionSpotlight->id} .active").removeClass('active').hide();
 				$("#" + selectedList).addClass('active').show();
 				// update view more link with data.url for the selectedOption
 				showList(availableLists.selectedIndex);

--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -28,7 +28,7 @@
 				<select class="availableLists" id="availableLists{$collectionSpotlight->id}" onchange="changeSelectedList();return false;" aria-label="{translate text="Select a list to display" isPublicFacing=true inAttribute=true}">
 					{foreach from=$collectionSpotlight->lists item=list}
 					{if $list->displayFor == 'all' || ($list->displayFor == 'loggedIn' && $loggedIn) || ($list->displayFor == 'notLoggedIn' && !$loggedIn)}
-					<option value="tab-{$list->id}">{translate text=$list->name isPublicFacing=true isAdminEnteredData=true inAttribute=true}</option>
+					<option data-carouselid="{$list->id}" value="tab-{$list->id}">{translate text=$list->name isPublicFacing=true isAdminEnteredData=true inAttribute=true}</option>
 					{/if}
 					{/foreach}
 				</select>
@@ -181,7 +181,8 @@
 
 				var selectedList = selectedOption.value;
 				$("#collectionSpotlight{$collectionSpotlight->id} .titleScroller.active").removeClass('active').hide();
-				$("#" + selectedList).addClass('active').show().jcarousel('reload');
+				$("#" + selectedList).addClass('active').show();
+				$('#collectionSpotlightCarousel' + selectedOption.dataset.carouselid).jcarousel('reload');
 			{rdelim}
 
 			$(document).ready(function(){ldelim}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -112,6 +112,7 @@
 
 			$(document).ready(function(){ldelim}
 				{if count($collectionSpotlight->lists) > 1 && (!isset($collectionSpotlight->listDisplayType) || $collectionSpotlight->listDisplayType == 'tabs')}
+				applyTabsSwitcher();
 				$('#collectionSpotlight{$collectionSpotlight->id} a[data-toggle="tab"]').on('shown.bs.tab', function (e) {ldelim}
 					showList($(e.target).data('index'));
 				{rdelim});

--- a/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
@@ -1,4 +1,4 @@
-<div role="tabpanel" aria-labelledby="spotlightTab{$list->id}" id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'small'} smallScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
+<div role="tabpanel" aria-labelledby="spotlightTab{$list->id}" id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller {$tabClasses}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'small'} smallScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
 {if !empty($showCollectionSpotlightTitle)}
 	<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">
 		{if !empty($showCollectionSpotlightTitle) && !empty($scrollerTitle)}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/singleTitleSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/singleTitleSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleSpotlight tab-pane{if !empty($active)} active{/if} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
+<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleSpotlight {$tabClasses} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper singleTitleSpotlightWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/singleTitleSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/singleTitleSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleSpotlight {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
+<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleSpotlight tab-pane{if !empty($active)} active{/if} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper singleTitleSpotlightWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/singleWithNextTitleSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/singleWithNextTitleSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleWithNextSpotlight {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
+<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleWithNextSpotlight tab-pane{if !empty($active)} active{/if} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper singleTitleSpotlightWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/singleWithNextTitleSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/singleWithNextTitleSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleWithNextSpotlight tab-pane{if !empty($active)} active{/if} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
+<div id="tab-{$wrapperId}" {if $display == 'false'}style="display:none"{/if} class="titleScroller singleTitleWithNextSpotlight {$tabClasses} {if $collectionSpotlight->coverSize == 'medium'}mediumScroller{/if} {if $collectionSpotlight->showRatings}scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper singleTitleSpotlightWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/textCollectionSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/textCollectionSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-	<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="textListScroller">
+	<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="textListScroller tab-pane{if !empty($active)} active{/if}">
 		<div id="{$wrapperId}" class="titleScrollerWrapper">
 			{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 				<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/textCollectionSpotlight.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/textCollectionSpotlight.tpl
@@ -1,5 +1,5 @@
 {strip}
-	<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="textListScroller tab-pane{if !empty($active)} active{/if}">
+	<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="textListScroller {$tabClasses}">
 		<div id="{$wrapperId}" class="titleScrollerWrapper">
 			{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 				<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/titleScroller.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/titleScroller.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
+<div id="tab-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller {$tabClasses}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper">
 		{if (!empty($showCollectionSpotlightTitle))}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/verticalTitleScroller.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/verticalTitleScroller.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="verticalTitleScroller tab-pane{if !empty($active)} active{/if}{if $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}">
+<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="verticalTitleScroller {$tabClasses}{if $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/interface/themes/responsive/CollectionSpotlight/verticalTitleScroller.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/verticalTitleScroller.tpl
@@ -1,5 +1,5 @@
 {strip}
-<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="verticalTitleScroller{if $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}">
+<div id="tab-{$wrapperId}"{if $display == 'false'} style="display:none"{/if} class="verticalTitleScroller tab-pane{if !empty($active)} active{/if}{if $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper">
 		{if (!empty($showCollectionSpotlightTitle) && $showCollectionSpotlightTitle) || $showViewMoreLink}
 			<div id="tab-{$wrapperId}Header" class="titleScrollerHeader">

--- a/code/web/release_notes/24.06.00.MD
+++ b/code/web/release_notes/24.06.00.MD
@@ -137,6 +137,9 @@
 //Pedro - PTFS
 ### Other Updates
 - Fix display of 'small' covers in collection spotlights (*PA*)
+- Fixed issue in collection spotlights 'Tabbed display' that prevented switching tabs when the display type was one of the following: 'Single Title', 'Single Title with next button' and 'Text Only List'
+- Fixed issue in collection spotlights 'Drop Down List' that prevented switching list using the dropdown list.
+- Fixed issue in collection spotlights that prevented the active tab from having the correct 'active' style appliedm in 'Tabbed display'
 
 ## This release includes code contributions from
 - ByWater Solutions


### PR DESCRIPTION
1) Perform a search
2) Scroll down to the bottom of the page. Click 'Create Spotlight'.
3) Enter name, click 'Create Spotlight'
4) Click "Edit" at the top.
5) For each display types of the following:
- Horizontal
- Horizontal Carousel
- Vertical
- Single Title
- Single Title with a Next Button
- Text Only List
6) Test both display modes:
- Tabbed Display
- Drop Down List
7) Make sure you have at least 2 lists created at the bottom of the edit page.
8) Verify that:
- Switching tabs works as expected for all display types
- Switching lists using the dropdown list works as expected for all display types

Before these patches:
- 'Vertical', 'Single Title', 'Single Title with next button' and 'Text Only List' did not allow to switch from tab to tab.
- When switching from the list dropdown it wouldn't change the list, but instead add to the one currently being viewed.
- The 'active' tab on 'Tabbed display' was not styled correctly for all displays other than 'horizontal-carousel'