### PR TITLE
fix: adjust code for facets to allow them to be unchecked

### DIFF
--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -11,6 +11,8 @@
 // katherine
 
 // alexander
+### Summon Updates
+- Adjustments to code in Summon getFacetSet function to correct a bug. Individual facet filters can now be unchecked and the filter unset by clicking the checkbox. (*AB*)
 
 // jacob
 

--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -486,7 +486,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 				foreach ($facetField['counts'] as $value) {
 					$facetValue = $value['value'];
 					//Ensures selected facet stays checked when selected - interacts with .tpl
-					$isApplied = array_key_exists($facetId, $this->filterList) && in_array($value, $this->filterList[$facetId]);
+					$isApplied = array_key_exists($facetId, $this->filterList) && in_array($facetValue, $this->filterList[$facetId]);
 					$facetSettings = [
 						'value' => $facetValue,
 						'display' =>$facetValue,
@@ -494,7 +494,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 						'isApplied' => $value['isApplied'],
 					];
 					if ($isApplied) {
-						$facetSettings['removalUrl'] = $this->renderLinkWithoutFilter($facetId . ':' . $value);
+						$facetSettings['removalUrl'] = $this->renderLinkWithoutFilter($facetId . ':' . $facetValue);
 					} else {
 						$facetSettings['url'] = $this->renderSearchUrl() . '&filter[]=' . $facetId . ':' . urlencode($facetValue);
 					}


### PR DESCRIPTION
Adjust code to allow Summon facet filters to be unchecked if they are clicked why $isApplied is true

TEST PLAN:
Before applying patch:
1) Carry out a Summon Search as usual
2) Apply and of the facets
3) Notice that the page reloads and the number of results reflects the chosen filter
4) Click the same filter again, notice the page reloads but the filter is still checked and applied
5) Click the red minus in the Applied Filters section for the filter you wish to remove
6) Notice that the page reloads and the filter has now been removed

APPLY PATCH:
1) Carry out a Summon Search and apply an filter as above
2) Click the same (checked) filter
3) Notice that the page reloads and the filter is now removed.