### PR TITLE
Cookie management updates

### DIFF
--- a/code/web/Drivers/Axis360Driver.php
+++ b/code/web/Drivers/Axis360Driver.php
@@ -708,7 +708,7 @@ class Axis360Driver extends AbstractEContentDriver {
 		$userUsage->instance = $aspenUsage->getInstance();
 		$userObj = UserAccount::getActiveUserObj();
 		$userAxis360Tracking = $userObj->userCookiePreferenceAxis360;
-		if ($userAxis260Tracking && $library->cookieStorageConsent){
+		if ($userAxis360Tracking && $library->cookieStorageConsent){
 			if ($userUsage->find(true)) {
 				$userUsage->usageCount++;
 				$userUsage->update();

--- a/code/web/Drivers/Axis360Driver.php
+++ b/code/web/Drivers/Axis360Driver.php
@@ -703,14 +703,19 @@ class Axis360Driver extends AbstractEContentDriver {
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
 		global $aspenUsage;
-		$userUsage->instance = $aspenUsage->getInstance();
+		global $library;
 
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		$userUsage->instance = $aspenUsage->getInstance();
+		$userObj = UserAccount::getActiveUserObj();
+		$userAxis360Tracking = $userObj->userCookiePreferenceAxis360;
+		if ($userAxis260Tracking && $library->cookieStorageConsent){
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/Drivers/CloudLibraryDriver.php
+++ b/code/web/Drivers/CloudLibraryDriver.php
@@ -759,17 +759,22 @@ class CloudLibraryDriver extends AbstractEContentDriver {
 	 */
 	public function trackUserUsageOfCloudLibrary($user): void {
 		require_once ROOT_DIR . '/sys/CloudLibrary/UserCloudLibraryUsage.php';
+		global $library;
+		$userObj = UserAccount::getActiveUserObj();
+		$userCloudLibraryTracking = $userObj->userCookiePreferenceCloudLibrary;
 		$userUsage = new UserCloudLibraryUsage();
 		$userUsage->userId = $user->id;
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
 
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		if ($userCloudLibraryTracking && $library->cookieStorageConsent) {
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/Drivers/HooplaDriver.php
+++ b/code/web/Drivers/HooplaDriver.php
@@ -681,19 +681,24 @@ class HooplaDriver extends AbstractEContentDriver {
 	 */
 	public function trackUserUsageOfHoopla($user): void {
 		require_once ROOT_DIR . '/sys/Hoopla/UserHooplaUsage.php';
+		global $library;
 		$userUsage = new UserHooplaUsage();
+		$userObj = UserAccount::getActiveUserObj();
+		$userHooplaTracking = $userObj->userCookiePreferenceHoopla;
 		global $aspenUsage;
 		$userUsage->instance = $aspenUsage->getInstance();
 		$userUsage->userId = $user->id;
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
 
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		if ($userHooplaTracking && $library->cookieStorageConsent) {
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -1618,18 +1618,22 @@ class OverDriveDriver extends AbstractEContentDriver {
 	public function trackUserUsageOfOverDrive($user): void {
 		require_once ROOT_DIR . '/sys/OverDrive/UserOverDriveUsage.php';
 		$userUsage = new UserOverDriveUsage();
+		$userObj = UserAccount::getActiveUserObj();
+		$userOverDriveTracking = $userObj->userCookiePreferenceOverdrive;
 		global $aspenUsage;
+		global $library;
 		$userUsage->instance = $aspenUsage->getInstance();
 		$userUsage->userId = $user->id;
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
-
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		if ($userOverDriveTracking && $library->cookieStorageConsent) {
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/Drivers/PalaceProjectDriver.php
+++ b/code/web/Drivers/PalaceProjectDriver.php
@@ -722,18 +722,22 @@ class PalaceProjectDriver extends AbstractEContentDriver {
 	public function trackUserUsageOfPalaceProject($user): void {
 		require_once ROOT_DIR . '/sys/PalaceProject/UserPalaceProjectUsage.php';
 		$userUsage = new UserPalaceProjectUsage();
+		$userObj = UserAccount::getActiveUserObj();
+		$userPalaceProjectTracking = $userObj->userCookiePreferencePalaceProject;
 		$userUsage->userId = $user->id;
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
 		global $aspenUsage;
+		global $library;
 		$userUsage->instance = $aspenUsage->getInstance();
-
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		if ($userPalaceProjectTracking && $library->cookieStorageConsent) {
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -280,9 +280,27 @@ if (!empty($library) && !empty($library->cookieStorageConsent)) {
 			if (!empty($cookie)) {
 				$analyticsPref = $cookie['Analytics'];
 				$userAxis360Pref = $cookie['UserAxis360'];
+				$userEbscoEdsPref = $cookie['UserEbscoEds'];
+				$userEbscoHostPref = $cookie['UserEbscoHost'];
+				$userSummonPref = $cookie['UserSummon'];
+				$userEventsPref = $cookie['UserEvents'];
+				$userHooplaPref = $cookie['UserHoopla'];
+				$userOpenArchivesPref = $cookie['UserOpenArchives'];
+				$userOverdrivePref = $cookie['UserOverdrive'];
+				$userPalaceProjectPref = $cookie['UserPalaceProject'];
+				$userSideLoadPref = $cookie['UserSideLoad'];
 				$userObj->userCookiePreferenceEssential = 1;
 				$userObj->userCookiePreferenceAnalytics = $analyticsPref;
 				$userObj->userCookiePreferenceAxis360 = $userAxis360Pref;
+				$userObj->userCookiePreferenceEbscoEds = $userEbscoEdsPref;
+				$userObj->userCookiePreferenceEbscoHost = $userEbscoHostPref;
+				$userObj->userCookiePreferenceSummon = $userSummonPref;
+				$userObj->userCookiePreferenceEvents = $userEventsPref;
+				$userObj->userCookiePreferenceHoopla = $userHooplaPref;
+				$userObj->userCookiePreferenceOpenArchives = $userOpenArchivesPref;
+				$userObj->userCookiePreferenceOverdrive = $userOverdrivePref;
+				$userObj->userCookiePreferencePalaceProject = $userPalaceProjectPref;
+				$userObj->userCookiePreferenceSideLoad = $userSideLoadPref;
 				$userObj->update();
 			}
 		}

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -279,8 +279,10 @@ if (!empty($library) && !empty($library->cookieStorageConsent)) {
 			$cookie = json_decode(urldecode($_COOKIE["cookieConsent"]), true);
 			if (!empty($cookie)) {
 				$analyticsPref = $cookie['Analytics'];
+				$userAxis360Pref = $cookie['UserAxis360'];
 				$userObj->userCookiePreferenceEssential = 1;
 				$userObj->userCookiePreferenceAnalytics = $analyticsPref;
+				$userObj->userCookiePreferenceAxis360 = $userAxis360Pref;
 				$userObj->update();
 			}
 		}

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -301,6 +301,8 @@ if (!empty($library) && !empty($library->cookieStorageConsent)) {
 				$userObj->userCookiePreferenceOverdrive = $userOverdrivePref;
 				$userObj->userCookiePreferencePalaceProject = $userPalaceProjectPref;
 				$userObj->userCookiePreferenceSideLoad = $userSideLoadPref;
+				$userObj->userCookiePreferenceCloudLibrary = $userCloudLibraryPref;
+				$userObj->userCookiePreferenceWebsite = $userWebsitePref;
 				$userObj->update();
 			}
 		}

--- a/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
+++ b/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
@@ -1,4 +1,20 @@
-  {strip}
+    {if $loggedIn}
+        <script>
+        cookieValues = {
+            Essential: {$profile->userCookiePreferenceEssential},
+            Analytics: {$profile->userCookiePreferenceAnalytics},
+            UserAxis360: {$profile->userCookiePreferenceAxis360},
+            UserEbscoEds: {$profile->userCookiePreferenceEbscoEds},
+            UserEbscoHost: {$profile->userCookiePreferenceEbscoHost},
+            UserSummon: {$profile->userCookiePreferenceSummon},
+            UserEvents: {$profile->userCookiePreferenceEvents},
+            UserHoopla: {$profile->userCookiePreferenceHoopla},
+            UserOpenArchives: {$profile->userCookiePreferenceOpenArchives},
+            UserOverdrive: {$profile->userCookiePreferenceOverdrive},
+            UserPalaceProject: {$profile->userCookiePreferencePalaceProject},    
+            UserSideLoad: {$profile->userCookiePreferenceSideLoad},
+        };
+        </script> 
        <div>
         <form method="post" name="cookieManagementPreferencesForm" id="cookieManagementPreferencesForm" class="form">
         <div>
@@ -16,8 +32,54 @@
             <input type="checkbox" name="cookieUserAxis360" id="cookieUserAxis360"> Axis 360
         </label>
     </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserEbscoEds" id="cookieUserEbscoEds"> Ebsco Eds
+    </label>
+    </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserEbscoHost" id="cookieUserEbscoHost"> Ebsco Host
+    </label>
+    </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserSummon" id="cookieUserSummon"> Summon
+    </label>
+    </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserEvents" id="cookieUserEvents"> Events
+    </label>
+    </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserHoopla" id="cookieUserHoopla"> Hoopla
+    </label>
+    </div>
+    <div>
+    <label>
+        <input type="checkbox" name="cookieUserOpenArchives" id="cookieUserOpenArchives"> Open Archives
+    </label>
+    </div>
+    <div>
+    <label>
+    <input type="checkbox" name="cookieUserOverdrive" id="cookieUserOpenOverdrive"> Overdrive
+    </label>
+    </div>
+    <div>
+    <label>
+    <input type="checkbox" name="cookieUserPalaceProject" id="cookieUserPalaceproject"> Palace Project
+    </label>
+    </div>
+    <div>
+    <label>
+    <input type="checkbox" name="cookieUserSideLoad" id="cookieUserSideLoad"> Side Load
+    </label>
+    </div>
+    <div>
             {* <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()" id="cookieConsentManage">{translate text="Save Preferences" isPublicFacing=true}</button> *}
             <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()">{translate text="Save Preferences" isPublicFacing=true}</button>
            </form>
        </div>
-        {/strip}
+    {/if}

--- a/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
+++ b/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
@@ -90,7 +90,6 @@
     </label>
     </div>
     <div>
-            {* <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()" id="cookieConsentManage">{translate text="Save Preferences" isPublicFacing=true}</button> *}
             <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()">{translate text="Save Preferences" isPublicFacing=true}</button>
            </form>
        </div>

--- a/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
+++ b/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
@@ -13,6 +13,8 @@
             UserOverdrive: {$profile->userCookiePreferenceOverdrive},
             UserPalaceProject: {$profile->userCookiePreferencePalaceProject},    
             UserSideLoad: {$profile->userCookiePreferenceSideLoad},
+            UserCloudLibrary: {$profile->userCookiePreferenceCloudLibrary},
+            UserWebsite: {$profile->userCookiePreferenceWebsite},
         };
         </script> 
        <div>
@@ -75,6 +77,16 @@
     <div>
     <label>
     <input type="checkbox" name="cookieUserSideLoad" id="cookieUserSideLoad"> Side Load
+    </label>
+    </div>
+    <div>
+    <label>
+    <input type="checkbox" name="cookieUserCloudLibrary" id="cookieUserCloudLibrary"> Cloud Library
+    </label>
+    </div>
+    <div>
+    <label>
+    <input type="checkbox" name="cookieUserWebsite" id="cookieUserWebsite"> Website
     </label>
     </div>
     <div>

--- a/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
+++ b/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
@@ -1,0 +1,23 @@
+  {strip}
+       <div>
+        <form method="post" name="cookieManagementPreferencesForm" id="cookieManagementPreferencesForm" class="form">
+        <div>
+        <label>
+            <input type="checkbox" name="cookieEssential" checked disabled> Essential Cookies
+        </label>
+    </div>
+    <div>
+        <label>
+            <input type="checkbox" name="cookieAnalytics"> Analytics Cookies
+        </label>
+    </div>
+    <div>
+        <label>
+            <input type="checkbox" name="cookieUserAxis360" id="cookieUserAxis360"> Axis 360
+        </label>
+    </div>
+            {* <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()" id="cookieConsentManage">{translate text="Save Preferences" isPublicFacing=true}</button> *}
+            <button type="submit" class="btn btn-sm btn-default" onclick="return AspenDiscovery.CookieConsent.cookieManagementPreferences()">{translate text="Save Preferences" isPublicFacing=true}</button>
+           </form>
+       </div>
+        {/strip}

--- a/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
+++ b/code/web/interface/themes/responsive/AJAX/cookieManagement.tpl
@@ -19,12 +19,12 @@
         <form method="post" name="cookieManagementPreferencesForm" id="cookieManagementPreferencesForm" class="form">
         <div>
         <label>
-            <input type="checkbox" name="cookieEssential" checked disabled> Essential Cookies
+            <input type="checkbox" name="cookieEssential" id="cookieEssential" checked disabled> Essential Cookies
         </label>
     </div>
     <div>
         <label>
-            <input type="checkbox" name="cookieAnalytics"> Analytics Cookies
+            <input type="checkbox" name="cookieAnalytics" id="cookieAnalytics"> Analytics Cookies
         </label>
     </div>
     <div>
@@ -69,7 +69,7 @@
     </div>
     <div>
     <label>
-    <input type="checkbox" name="cookieUserPalaceProject" id="cookieUserPalaceproject"> Palace Project
+    <input type="checkbox" name="cookieUserPalaceProject" id="cookieUserPalaceProject"> Palace Project
     </label>
     </div>
     <div>

--- a/code/web/interface/themes/responsive/MyAccount/account-sidebar.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/account-sidebar.tpl
@@ -228,6 +228,8 @@
 						<div class="panel-body">
 							{if empty($offline)}
 								{if !empty($showUserPreferences)}<div class="myAccountLink"><a href="/MyAccount/MyPreferences">{translate text='Your Preferences' isPublicFacing=true}</a></div>{/if}
+								{if $cookieConsentEnabled}	<div class="header-menu-option"><a href="/MyAccount/MyCookiePreferences">{translate text="Your Cookie Preferences" isPublicFacing=true}</a></div>{/if}
+
 								{if !empty($showUserContactInformation)}<div class="myAccountLink"><a href="/MyAccount/ContactInformation">{translate text='Contact Information' isPublicFacing=true}</a></div>{/if}
 								{if $user->showHoldNotificationPreferences()}
 									<div class="myAccountLink"><a href="/MyAccount/HoldNotificationPreferences">{translate text='Hold Notification Preferences' isPublicFacing=true}</a></div>

--- a/code/web/interface/themes/responsive/MyAccount/myCookiePreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myCookiePreferences.tpl
@@ -1,0 +1,154 @@
+{strip}
+	<div id="main-content">
+		{if !empty($loggedIn)}
+			{if !empty($profile->_web_note)}
+				<div class="row">
+					<div id="web_note" class="alert alert-info text-center col-xs-12">{$profile->_web_note}</div>
+				</div>
+			{/if}
+			{if !empty($accountMessages)}
+				{include file='systemMessages.tpl' messages=$accountMessages}
+			{/if}
+			{if !empty($ilsMessages)}
+				{include file='ilsMessages.tpl' messages=$ilsMessages}
+			{/if}
+
+			<h1>{translate text='My Cookie Preferences' isPublicFacing=true}</h1>
+			{if !empty($profileUpdateMessage)}
+				{foreach from=$profileUpdateMessage item=msg}
+					<div class="alert alert-success">{$msg}</div>
+				{/foreach}
+			{/if}
+			{if !empty($offline)}
+				<div class="alert alert-warning"><strong>{translate text=$offlineMessage isPublicFacing=true}</strong></div>
+			{else}
+				{* Empty action attribute uses the page loaded. this keeps the selected user patronId in the parameters passed back to server *}
+				<form action="" method="post" role="form">
+					<input type="hidden" name="updateScope" value="userCookiePreference">
+					<input type="hidden" name="patronId" value={$profile->id|escape}>
+					{if !empty($showUsernameField)}
+						<div class="form-group propertyRow">
+							<label for="username">{translate text="Username" isPublicFacing=true}</label>
+							<input type="text" name="username" id="username" value="{$editableUsername|escape}" size="25" minlength="6" maxlength="25" class="form-control">
+							<a id="usernameHelpButton" href="#" role="button" aria-controls="usernameHelp" aria-expanded="false"><i class="fa fa-question-circle" role="presentation"></i> {translate text="What is this?" isPublicFacing=true}</a>
+							<div id="usernameHelp" style="display:none">
+								<p>{translate text="A username is an optional feature. If you set one, your username will be your alias on hold slips and can also be used to log into your account in place of your card number.  A username can be set, reset or removed from the “My Preferences” section of your online account. Usernames must be between 6 and 25 characters (letters and number only, no special characters)." isPublicFacing=true}</p>
+							</div>
+						</div>
+					{/if}
+
+					{*TODO:: At the moment, if a user ignores the cookie consent banner, the essential cookies are set to zero, so this does not show in the my accout preferences - check with MN*}
+					{if !empty($loggedIn) && !empty($cookieConsentEnabled)}
+						<div class="form-group #propertyRow">
+						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
+						<div style='padding:0.5em 1em;'>
+							<div class="form-group propertyRow">
+								<label for='userCookieEssential' class="control-label">{translate text="Essential" isPublicFacing=true}</label>&nbsp;
+								<input disabled="disabled" type="checkbox" class="form-control" name="userCookieEssential" id="userCookieEssential" {if $profile->userCookiePreferenceEssential==1}checked='checked'{/if} data-switch="">
+
+							</div> 
+							<div class="form-group propertyRow">
+								<label for='userCookieAnalytics' class="control-label">{translate text="Analytics" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
+
+							</div> 
+
+							<div class="form-group propertyRow">
+								<label for='userCookieUserAxis360' class="control-label">{translate text="Axis 360" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
+
+							</div> 
+
+							<div class="form-group propertyRow">
+								<label for='userCookieUserEbscoEds' class="control-label">{translate text="Ebsco Eds" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieUserEbscoEds" id="userCookieUserEbscoEds" {if $profile->userCookiePreferenceEbscoEds==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserEbscoHost' class="control-label">{translate text="Ebsco Host" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserEbscoHost" id="userCookieUserEbscoHost" {if $profile->userCookiePreferenceEbscoHost==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserSummon' class="control-label">{translate text="Summon" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserSummon" id="userCookieUserSummon" {if $profile->userCookiePreferenceSummon==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserEvents' class="control-label">{translate text="Events" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserEvents" id="userCookieUserEvents" {if $profile->userCookiePreferenceEvents==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserHoopla' class="control-label">{translate text="Hoopla" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserHoopla" id="userCookieUserHoopla" {if $profile->userCookiePreferenceHoopla==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserOpenArchives' class="control-label">{translate text="Open Archives" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserOpenArchives" id="userCookieUserOpenArchives" {if $profile->userCookiePreferenceOpenArchives==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserOverdrive' class="control-label">{translate text="Overdrive" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserOverdrive" id="userCookieUserOverdrive" {if $profile->userCookiePreferenceOverdrive==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserPalaceproject' class="control-label">{translate text="Palace Project" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserPalaceProject" id="userCookieUserPalaceProject" {if $profile->userCookiePreferencePalaceProject==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserSideLoad' class="control-label">{translate text="Side Load" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserCloudLibrary' class="control-label">{translate text="Cloud Library" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserCloudLibrary" id="userCookieUserCloudLibrary" {if $profile->userCookiePreferenceCloudLibrary==1}checked='checked'{/if} data-switch="">
+
+							</div>
+
+							<div class="form-group propertyRow">
+							<label for='userCookieUserWebsite' class="control-label">{translate text="Website" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserWebsite" id="userCookieUserWebsite" {if $profile->userCookiePreferenceWebsite==1}checked='checked'{/if} data-switch="">
+
+							</div>
+			
+						</div>
+					{/if}
+
+					{if empty($offline) && $edit == true}
+						<div class="form-group propertyRow">
+							<button type="submit" name="updateMyCookiePreferences" class="btn btn-sm btn-primary">{translate text="Update My Cookie Preferences" isPublicFacing=true}</button>
+						</div>
+					{/if}
+				</form>
+
+				<script type="text/javascript">
+					{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
+					{literal}
+					$(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
+					$("#usernameHelpButton").click(function() {
+						var helpButton = $(this);
+						if (helpButton.attr("aria-expanded") === "true") {
+							$("#usernameHelp").css('display', 'none');
+							$("#usernameHelpButton").attr("aria-expanded","false");
+						}
+						else if (helpButton.attr("aria-expanded") === "false") {
+							$("#usernameHelp").css('display', 'block');
+							$("#usernameHelpButton").attr("aria-expanded","true");
+						}
+						return false;
+					})
+					{/literal}
+				</script>
+			{/if}
+		{else}
+			<div class="page">
+				{translate text="You must sign in to view this information." isPublicFacing=true}<a href='/MyAccount/Login' class="btn btn-primary">{translate text="Sign In" isPublicFacing=true}</a>
+			</div>
+		{/if}
+	</div>
+{/strip}

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -203,87 +203,6 @@
 							&nbsp;{if $profile->disableCirculationActions==1} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
 						{/if}
 					</div>
-						{*TODO:: At the moment, if a user ignores the cookie consent banner, the essential cookies are set to zero, so this does not show in the my accout preferences - check with MN*}
-					{if !empty($loggedIn) && !empty($cookieConsentEnabled)}
-						<div class="form-group #propertyRow">
-						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
-						<div style='padding:0.5em 1em;'>
-							<div class="form-group propertyRow">
-								<label for='userCookieEssential' class="control-label">{translate text="Essential" isPublicFacing=true}</label>&nbsp;
-								<input disabled="disabled" type="checkbox" class="form-control" name="userCookieEssential" id="userCookieEssential" {if $profile->userCookiePreferenceEssential==1}checked='checked'{/if} data-switch="">
-
-							</div> 
-							<div class="form-group propertyRow">
-								<label for='userCookieAnalytics' class="control-label">{translate text="Analytics" isPublicFacing=true}</label>&nbsp;
-								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
-
-							</div> 
-
-							<div class="form-group propertyRow">
-								<label for='userCookieUserAxis360' class="control-label">{translate text="Axis 360" isPublicFacing=true}</label>&nbsp;
-								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
-
-							</div> 
-
-							<div class="form-group propertyRow">
-								<label for='userCookieUserEbscoEds' class="control-label">{translate text="Ebsco Eds" isPublicFacing=true}</label>&nbsp;
-								<input type="checkbox" class="form-control" name="userCookieUserEbscoEds" id="userCookieUserEbscoEds" {if $profile->userCookiePreferenceEbscoEds==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserEbscoHost' class="control-label">{translate text="Ebsco Host" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserEbscoHost" id="userCookieUserEbscoHost" {if $profile->userCookiePreferenceEbscoHost==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserSummon' class="control-label">{translate text="Summon" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserSummon" id="userCookieUserSummon" {if $profile->userCookiePreferenceSummon==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserEvents' class="control-label">{translate text="Events" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserEvents" id="userCookieUserEvents" {if $profile->userCookiePreferenceEvents==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserHoopla' class="control-label">{translate text="Hoopla" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserHoopla" id="userCookieUserHoopla" {if $profile->userCookiePreferenceHoopla==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserOpenArchives' class="control-label">{translate text="Open Archives" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserOpenArchives" id="userCookieUserOpenArchives" {if $profile->userCookiePreferenceOpenArchives==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserOverdrive' class="control-label">{translate text="Overdrive" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserOverdrive" id="userCookieUserOverdrive" {if $profile->userCookiePreferenceOverdrive==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserPalaceproject' class="control-label">{translate text="Palace Project" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserPalaceProject" id="userCookieUserPalaceProject" {if $profile->userCookiePreferencePalaceProject==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserSideLoad' class="control-label">{translate text="Side Load" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
-
-							</div>
-							<div class="form-group propertyRow">
-							<label for='userCookieUserCloudLibrary' class="control-label">{translate text="Cloud Library" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserCloudLibrary" id="userCookieUserCloudLibrary" {if $profile->userCookiePreferenceCloudLibrary==1}checked='checked'{/if} data-switch="">
-
-							</div>
-
-							<div class="form-group propertyRow">
-							<label for='userCookieUserWebsite' class="control-label">{translate text="Website" isPublicFacing=true}</label>&nbsp;
-							<input type="checkbox" class="form-control" name="userCookieUserWebsite" id="userCookieUserWebsite" {if $profile->userCookiePreferenceWebsite==1}checked='checked'{/if} data-switch="">
-
-							</div>
-			
-						</div>
-					{/if}
 
 					{if empty($offline) && $edit == true}
 						<div class="form-group propertyRow">
@@ -292,10 +211,10 @@
 					{/if}
 				</form>
 
-				<script type="text/javascript">
+				{* <script type="text/javascript">
 					{* Initiate any checkbox with a data attribute set to data-switch=""  as a bootstrap switch *}
 					{literal}
-					$(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
+					<!-- $(function(){ $('input[type="checkbox"][data-switch]').bootstrapSwitch()});
 					$("#usernameHelpButton").click(function() {
 						var helpButton = $(this);
 						if (helpButton.attr("aria-expanded") === "true") {
@@ -307,9 +226,9 @@
 							$("#usernameHelpButton").attr("aria-expanded","true");
 						}
 						return false;
-					})
+					}) -->
 					{/literal}
-				</script>
+				</script> *}
 			{/if}
 		{else}
 			<div class="page">

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -270,6 +270,17 @@
 							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
 
 							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserCloudLibrary' class="control-label">{translate text="Cloud Library" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserCloudLibrary" id="userCookieUserCloudLibrary" {if $profile->userCookiePreferenceCloudLibrary==1}checked='checked'{/if} data-switch="">
+
+							</div>
+
+							<div class="form-group propertyRow">
+							<label for='userCookieUserWebsite' class="control-label">{translate text="Website" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserWebsite" id="userCookieUserWebsite" {if $profile->userCookiePreferenceWebsite==1}checked='checked'{/if} data-switch="">
+
+							</div>
 			
 						</div>
 					{/if}

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -204,28 +204,28 @@
 						{/if}
 					</div>
 						{*TODO:: At the moment, if a user ignores the cookie consent banner, the essential cookies are set to zero, so this does not show in the my accout preferences - check with MN*}
-					{* {if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)} *}
+					{if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)}
 						<div class="form-group #propertyRow">
 						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
 						<div style='padding:0.5em 1em;'>
-							{* <div class="form-group propertyRow">
+							<div class="form-group propertyRow">
 								<label for='userCookieEssential' class="control-label">{translate text="Essential" isPublicFacing=true}</label>&nbsp;
 								<input disabled="disabled" type="checkbox" class="form-control" name="userCookieEssential" id="userCookieEssential" {if $profile->userCookiePreferenceEssential==1}checked='checked'{/if} data-switch="">
 
-							</div> *}
-							{* <div class="form-group propertyRow">
+							</div> 
+							<div class="form-group propertyRow">
 								<label for='userCookieAnalytics' class="control-label">{translate text="Analytics" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
 
-							</div> *}
+							</div> 
 
-							{* <div class="form-group propertyRow">
+							<div class="form-group propertyRow">
 								<label for='userCookieUserAxis360' class="control-label">{translate text="Axis 360" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
 
-							</div> *}
+							</div> 
 
-							{* <div class="form-group propertyRow">
+							<div class="form-group propertyRow">
 								<label for='userCookieUserEbscoEds' class="control-label">{translate text="Ebsco Eds" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieUserEbscoEds" id="userCookieUserEbscoEds" {if $profile->userCookiePreferenceEbscoEds==1}checked='checked'{/if} data-switch="">
 
@@ -270,9 +270,9 @@
 							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
 
 							</div>
-			 *}
+			
 						</div>
-					{* {/if} *}
+					{/if}
 
 					{if empty($offline) && $edit == true}
 						<div class="form-group propertyRow">

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -218,6 +218,12 @@
 								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
 
 							</div>
+
+							<div class="form-group propertyRow">
+								<label for='userCookieUserAxis360' class="control-label">{translate text="Axia 360" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
+
+							</div>
 						</div>
 					{/if}
 

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -220,10 +220,57 @@
 							</div>
 
 							<div class="form-group propertyRow">
-								<label for='userCookieUserAxis360' class="control-label">{translate text="Axia 360" isPublicFacing=true}</label>&nbsp;
+								<label for='userCookieUserAxis360' class="control-label">{translate text="Axis 360" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
 
 							</div>
+
+							<div class="form-group propertyRow">
+								<label for='userCookieUserEbscoEds' class="control-label">{translate text="Ebsco Eds" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieUserEbscoEds" id="userCookieUserEbscoEds" {if $profile->userCookiePreferenceEbscoEds==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserEbscoHost' class="control-label">{translate text="Ebsco Host" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserEbscoHost" id="userCookieUserEbscoHost" {if $profile->userCookiePreferenceEbscoHost==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserSummon' class="control-label">{translate text="Summon" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserSummon" id="userCookieUserSummon" {if $profile->userCookiePreferenceSummon==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserEvents' class="control-label">{translate text="Events" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserEvents" id="userCookieUserEvents" {if $profile->userCookiePreferenceEvents==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserHoopla' class="control-label">{translate text="Hoopla" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserHoopla" id="userCookieUserHoopla" {if $profile->userCookiePreferenceHoopla==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserOpenArchives' class="control-label">{translate text="Open Archives" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserOpenArchives" id="userCookieUserOpenArchives" {if $profile->userCookiePreferenceOpenArchives==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserOverdrive' class="control-label">{translate text="Overdrive" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserOverdrive" id="userCookieUserOverdrive" {if $profile->userCookiePreferenceOverdrive==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserPalaceproject' class="control-label">{translate text="Palace Project" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserPalaceProject" id="userCookieUserPalaceProject" {if $profile->userCookiePreferencePalaceProject==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+							<label for='userCookieUserSideLoad' class="control-label">{translate text="Side Load" isPublicFacing=true}</label>&nbsp;
+							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
+
+							</div>
+			
 						</div>
 					{/if}
 

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -203,29 +203,29 @@
 							&nbsp;{if $profile->disableCirculationActions==1} {translate text='No' isPublicFacing=true}{else} {translate text='Yes' isPublicFacing=true}{/if}
 						{/if}
 					</div>
-
-					{if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)}
+						{*TODO:: At the moment, if a user ignores the cookie consent banner, the essential cookies are set to zero, so this does not show in the my accout preferences - check with MN*}
+					{* {if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)} *}
 						<div class="form-group #propertyRow">
 						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
 						<div style='padding:0.5em 1em;'>
-							<div class="form-group propertyRow">
+							{* <div class="form-group propertyRow">
 								<label for='userCookieEssential' class="control-label">{translate text="Essential" isPublicFacing=true}</label>&nbsp;
 								<input disabled="disabled" type="checkbox" class="form-control" name="userCookieEssential" id="userCookieEssential" {if $profile->userCookiePreferenceEssential==1}checked='checked'{/if} data-switch="">
 
-							</div>
-							<div class="form-group propertyRow">
+							</div> *}
+							{* <div class="form-group propertyRow">
 								<label for='userCookieAnalytics' class="control-label">{translate text="Analytics" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
 
-							</div>
+							</div> *}
 
-							<div class="form-group propertyRow">
+							{* <div class="form-group propertyRow">
 								<label for='userCookieUserAxis360' class="control-label">{translate text="Axis 360" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieUserAxis360" id="userCookieUserAxis360" {if $profile->userCookiePreferenceAxis360==1}checked='checked'{/if} data-switch="">
 
-							</div>
+							</div> *}
 
-							<div class="form-group propertyRow">
+							{* <div class="form-group propertyRow">
 								<label for='userCookieUserEbscoEds' class="control-label">{translate text="Ebsco Eds" isPublicFacing=true}</label>&nbsp;
 								<input type="checkbox" class="form-control" name="userCookieUserEbscoEds" id="userCookieUserEbscoEds" {if $profile->userCookiePreferenceEbscoEds==1}checked='checked'{/if} data-switch="">
 
@@ -270,9 +270,9 @@
 							<input type="checkbox" class="form-control" name="userCookieUserSideLoad" id="userCookieUserSideLoad" {if $profile->userCookiePreferenceSideLoad==1}checked='checked'{/if} data-switch="">
 
 							</div>
-			
+			 *}
 						</div>
-					{/if}
+					{* {/if} *}
 
 					{if empty($offline) && $edit == true}
 						<div class="form-group propertyRow">

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -204,7 +204,7 @@
 						{/if}
 					</div>
 						{*TODO:: At the moment, if a user ignores the cookie consent banner, the essential cookies are set to zero, so this does not show in the my accout preferences - check with MN*}
-					{if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)}
+					{if !empty($loggedIn) && !empty($cookieConsentEnabled)}
 						<div class="form-group #propertyRow">
 						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
 						<div style='padding:0.5em 1em;'>

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
@@ -9,7 +9,7 @@
             {if !empty($showCovers)}
                 <div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
                     {if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
-                        <a href="{$summUrl}" onclick="AsepnDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank" aria-hidden="true">
+                        <a href="{$summUrl}" onclick="AspenDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank" aria-hidden="true">
                             <img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
                         </a>
                     {/if}

--- a/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Summon/listEntry.tpl
@@ -9,7 +9,7 @@
             {if !empty($showCovers)}
                 <div class="col-xs-3 col-sm-3 col-md-3 col-lg-2 text-center">
                     {if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
-                        <a href="{$summUrl}" target="_blank" aria-hidden="true">
+                        <a href="{$summUrl}" onclick="AsepnDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank" aria-hidden="true">
                             <img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
                         </a>
                     {/if}
@@ -20,7 +20,7 @@
                 <div class="row">
                     <div class="col-xs-12">
                         <span class="result-index">{$resultIndex})</span>&nbsp;
-                        <a href="{$summUrl}" class="result-title notranslate" target="_blank" aria-label="{if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|truncate:180:"..."|highlight}{/if} ({translate text='opens in new window' isPublicFacing=true})">
+                        <a href="{$summUrl}" class="result-title notranslate" onclick="AspenDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank" aria-label="{if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|truncate:180:"..."|highlight}{/if} ({translate text='opens in new window' isPublicFacing=true})">
                             {if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|truncate:180:"..."|highlight}{/if}
                         </a>
                     </div>

--- a/code/web/interface/themes/responsive/Summon/list.tpl
+++ b/code/web/interface/themes/responsive/Summon/list.tpl
@@ -1,4 +1,4 @@
-<h1 class="hiddenTitle">{translate text='Events Search Results' isPublicFacing=true}</h1>
+<h1 class="hiddenTitle">{translate text='Articles & Databases Search Results'}</h1>
 <div id="searchInfo">
 	{* Recommendations *}
 	{if !empty($topRecommendations)}
@@ -7,43 +7,16 @@
 		{/foreach}
 	{/if}
 
-	{* Information about the search *}
 	<div class="result-head">
-
-		{if !empty($replacementTerm)}
-			<div id="replacement-search-info-block">
-				<div id="replacement-search-info"><span class="replacement-search-info-text">{translate text="Showing Results for" isPublicFacing=true}</span> {$replacementTerm}</div>
-				<div id="original-search-info"><span class="replacement-search-info-text">{translate text="Search instead for" isPublicFacing=true} </span><a href="{$oldSearchUrl}">{$oldTerm}</a></div>
-			</div>
-		{/if}
-
-		{if !empty($solrSearchDebug)}
-			<div id="solrSearchOptionsToggle" onclick="$('#solrSearchOptions').toggle()">{translate text="Show Search Options" isAdminFacing=true}</div>
-			<div id="solrSearchOptions" style="display:none">
-				<pre>{translate text="Search options" isPublicFacing=true} {$solrSearchDebug}</pre>
-			</div>
-		{/if}
-
-		{if !empty($solrLinkDebug)}
-			<div id='solrLinkToggle' onclick='$("#solrLink").toggle()'>{translate text="Show Solr Link" isAdminFacing=true}</div>
-			<div id='solrLink' style='display:none'>
-				<pre>{$solrLinkDebug}</pre>
-			</div>
-		{/if}
-
-		{if !empty($debugTiming)}
-			<div id='solrTimingToggle' onclick='$("#solrTiming").toggle()'>{translate text="Show Solr Timing" isAdminFacing=true}</div>
-			<div id='solrTiming' style='display:none'>
-				<pre>{$debugTiming}</pre>
-			</div>
-		{/if}
-
 		{* User's viewing mode toggle switch *}
-		{include file="Events/results-displayMode-toggle.tpl"}
+		{if !empty($showSearchToolsAtTop)}
+			{include file="Search/search-toolbar.tpl"}
+		{else}
+			{include file="Search/results-displayMode-toggle.tpl"}
+		{/if}
 
 		<div class="clearer"></div>
 	</div>
-	{* End Listing Options *}
 
 	{if !empty($subpage)}
 		{include file=$subpage}
@@ -51,60 +24,28 @@
 		{$pageContent}
 	{/if}
 
-	{if $displayMode == 'covers'}
-		{if $recordEnd < $recordCount}
-			<a onclick="return AspenDiscovery.Searches.getMoreResults()" role="button" title="{translate text='Get More Results' inAttribute=true isPublicFacing=true}">
-				<div class="row" id="more-browse-results">
-					<span class="glyphicon glyphicon-chevron-down" aria-label="{translate text='Get More Results' inAttribute=true isPublicFacing=true}" role="button"></span>
-				</div>
-			</a>
-		{/if}
-	{else}
-		{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
-	{/if}
+	{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
 
-	{if $showSearchTools || ($loggedIn && count($userPermissions) > 0)}
-	<div class="search_tools well small">
-		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
-		{if !empty($showSearchTools) && (empty($offline) || $enableEContentWhileOffline)}
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+	{if !empty($showSearchTools) && !$showSearchToolsAtTop}
+		<div class="search_tools well small">
+			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
+			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
+			{if empty($offline) || $enableEContentWhileOffline}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
-			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}
-		{/if}
-		{if !empty($loggedIn) && (in_array('Administer All Collection Spotlights', $userPermissions) || in_array('Administer Library Collection Spotlights', $userPermissions))}
-			<a href="#" onclick="return AspenDiscovery.CollectionSpotlights.createSpotlightFromSearch('{$searchId}')">{translate text='Create Spotlight' isAdminFacing=true}</a>
-		{/if}
-		{if !empty($loggedIn) && (in_array('Administer All Browse Categories', $userPermissions) || in_array('Administer Library Browse Categories', $userPermissions) || in_array('Administer Selected Browse Category Groups', $userPermissions))}
-			<a href="#" onclick="return AspenDiscovery.Browse.addToHomePage('{$searchId}')">{translate text='Add To Browse' isPublicFacing=true}</a>
-		{/if}
-	</div>
+			{if !empty($loggedIn) && (in_array('Administer All Collection Spotlights', $userPermissions) || in_array('Administer Library Collection Spotlights', $userPermissions))}
+				<a href="#" onclick="return AspenDiscovery.CollectionSpotlights.createSpotlightFromSearch('{$searchId}')">{translate text='Create Spotlight' isAdminFacing=true}</a>
+			{/if}
+			{if !empty($loggedIn) && (in_array('Administer All Browse Categories', $userPermissions) || in_array('Administer Library Browse Categories', $userPermissions) || in_array('Administer Selected Browse Category Groups', $userPermissions))}
+				<a href="#" onclick="return AspenDiscovery.Browse.addToHomePage('{$searchId}')">{translate text='Add To Browse' isPublicFacing=true}</a>
+			{/if}
+		</div>
 	{/if}
 </div>
-
-{* Embedded Javascript For this Page *}
-<script type="text/javascript">
-	$(function(){ldelim}
-		if ($('#horizontal-menu-bar-container').is(':visible')) {ldelim}
-			$('#home-page-search').show();  {*// Always show the searchbox for search results in mobile views.*}
-		{rdelim}
-
-		AspenDiscovery.Summon.getSummonResults("{$lookfor|escapeCSS}");
-		
-
-		{if empty($onInternalIP)}
-			{* Because content is served on the page, have to set the mode that was used, even if the user didn't choose the mode. *}
-			AspenDiscovery.Searches.displayMode = '{$displayMode}';
-		{else}
-			AspenDiscovery.Searches.displayMode = '{$displayMode}';
-			Globals.opac = 1; {* set to true to keep opac browsers from storing browse mode *}
-		{/if}
-		$('#'+AspenDiscovery.Searches.displayMode).parent('label').addClass('active'); {* show user which one is selected *}
-
-		{rdelim});
-</script>

--- a/code/web/interface/themes/responsive/account-menu.tpl
+++ b/code/web/interface/themes/responsive/account-menu.tpl
@@ -75,6 +75,7 @@
 				</div>
 			{/if}
 			{if !empty($showUserPreferences)}<div class="header-menu-option" ><a href="/MyAccount/MyPreferences">{translate text='Your Preferences' isPublicFacing=true}</a></div>{/if}
+			{if $cookieConsentEnabled}	<div class="header-menu-option"><a href="/MyAccount/MyCookiePreferences">{translate text="Your Cookie Preferences" isPublicFacing=true}</a></div>{/if}
 			{if !empty($showUserContactInformation)}<div class="header-menu-option" ><a href="/MyAccount/ContactInformation">{translate text='Contact Information' isPublicFacing=true}</a></div>{/if}
 			{if $user->showHoldNotificationPreferences()}
 				<div class="header-menu-option" ><a href="/MyAccount/HoldNotificationPreferences">{translate text='Hold Notification Preferences' isPublicFacing=true}</a></div>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -3,6 +3,18 @@
         cookieValues = {
             Essential: {$profile->userCookiePreferenceEssential},
             Analytics: {$profile->userCookiePreferenceAnalytics},
+            UserAxis360: {$profile->userCookiePreferenceAxis360},
+            UserEbscoEds: {$profile->userCookiePreferenceEbscoEds},
+            UserEbscoHost: {$profile->userCookiePreferenceEbscoHost},
+            UserSummon: {$profile->userCookiePreferenceSummon},
+            UserEvents: {$profile->userCookiePreferenceEvents},
+            UserHoopla: {$profile->userCookiePreferenceHoopla},
+            UserOpenArchives: {$profile->userCookiePreferenceOpenArchives},
+            UserOverdrive: {$profile->userCookiePreferenceOverdrive},
+            UserPalaceProject: {$profile->userCookiePreferencePalaceProject},    
+            UserSideLoad: {$profile->userCookiePreferenceSideLoad},
+            UserCloudLibrary: {$profile->userCookiePreferenceCloudLibrary},
+            UserWebsite: {$profile->userCookiePreferenceWebsite},
         };
         AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
     </script>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -4,6 +4,15 @@
             Essential: {$profile->userCookiePreferenceEssential},
             Analytics: {$profile->userCookiePreferenceAnalytics},
             UserAxis360: {$profile->userCookiePreferenceAxis360},
+            UserEbscoEds: {$profile->userCookiePreferenceEbscoEds},
+            UserEbscoHost: {$profile->userCookiePreferenceEbscoHost},
+            UserSummon: {$profile->userCookiePreferenceSummon},
+            UserEvents: {$profile->userCookiePreferenceEvents},
+            UserHoopla: {$profile->userCookiePreferenceHoopla},
+            UserOpenArchives: {$profile->userCookiePreferenceOpenArchives},
+            UserOverdrive: {$profile->userCookiePreferenceOverdrive},
+            UserPalaceProject: {$profile->userCookiePreferencePalaceProject},    
+            UserSideLoad: {$profile->userCookiePreferenceSideLoad},        
         };
         AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
     </script>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,5 +1,5 @@
-{if $loggedIn && $profile->userCookiePreferenceEssential == 1}
-    <script>
+{* {if $loggedIn && $profile->userCookiePreferenceEssential == 1} *}
+    {* <script>
         cookieValues = {
             Essential: {$profile->userCookiePreferenceEssential},
             Analytics: {$profile->userCookiePreferenceAnalytics},
@@ -15,8 +15,8 @@
             UserSideLoad: {$profile->userCookiePreferenceSideLoad},        
         };
         AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
-    </script>
-{elseif (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))} 
+    </script> *}
+{* {elseif (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))}  *}
     <div class="stripPopup">
         <div class="cookieContainer">
             <div class="contentWrap">
@@ -30,4 +30,3 @@
             </div>
         </div>
     </div>
-{/if}

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,13 +1,36 @@
- <div class="stripPopup">
-        <div class="cookieContainer">
-            <div class="contentWrap">
-                <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
-                <abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
-            </div>
-            <div class="btnWrap">
-                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
-                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
-                <a onclick="AspenDiscovery.CookieConsent.cookieManage();" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
-            </div>
+{if $loggedIn && $profile->userCookiePreferenceEssential == 1}
+    <script>
+        cookieValues = {
+            Essential: {$profile->userCookiePreferenceEssential},
+            Analytics: {$profile->userCookiePreferenceAnalytics},
+        };
+        AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
+    </script>
+{elseif $loggedIn && (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))} 
+    <div class="stripPopup">
+    <div class="cookieContainer">
+        <div class="contentWrap">
+            <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
+            <abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
+        </div>
+        <div class="btnWrap">
+            <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
+            <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
+            <a onclick="AspenDiscovery.CookieConsent.cookieManage();" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
         </div>
     </div>
+</div>
+{elseif !$loggedIn && (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))}
+    <div class="stripPopup">
+    <div class="cookieContainer">
+        <div class="contentWrap">
+            <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
+            <abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
+        </div>
+        <div class="btnWrap">
+            <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
+            <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
+        </div>
+    </div>
+</div>
+{/if}

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -3,6 +3,7 @@
         cookieValues = {
             Essential: {$profile->userCookiePreferenceEssential},
             Analytics: {$profile->userCookiePreferenceAnalytics},
+            UserAxis360: {$profile->userCookiePreferenceAxis360},
         };
         AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
     </script>
@@ -16,7 +17,7 @@
             <div class="btnWrap">
                 <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
                 <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
-                <a onclick="AspenDiscovery.CookieConsent.cookieManage('manage');" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
+                <a onclick="AspenDiscovery.CookieConsent.cookieManage();" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
             </div>
         </div>
     </div>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,23 +1,4 @@
-{* {if $loggedIn && $profile->userCookiePreferenceEssential == 1} *}
-    {* <script>
-        cookieValues = {
-            Essential: {$profile->userCookiePreferenceEssential},
-            Analytics: {$profile->userCookiePreferenceAnalytics},
-            UserAxis360: {$profile->userCookiePreferenceAxis360},
-            UserEbscoEds: {$profile->userCookiePreferenceEbscoEds},
-            UserEbscoHost: {$profile->userCookiePreferenceEbscoHost},
-            UserSummon: {$profile->userCookiePreferenceSummon},
-            UserEvents: {$profile->userCookiePreferenceEvents},
-            UserHoopla: {$profile->userCookiePreferenceHoopla},
-            UserOpenArchives: {$profile->userCookiePreferenceOpenArchives},
-            UserOverdrive: {$profile->userCookiePreferenceOverdrive},
-            UserPalaceProject: {$profile->userCookiePreferencePalaceProject},    
-            UserSideLoad: {$profile->userCookiePreferenceSideLoad},        
-        };
-        AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
-    </script> *}
-{* {elseif (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))}  *}
-    <div class="stripPopup">
+ <div class="stripPopup">
         <div class="cookieContainer">
             <div class="contentWrap">
                 <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -16,6 +16,7 @@
             <div class="btnWrap">
                 <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
                 <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
+                <a onclick="AspenDiscovery.CookieConsent.cookieManage('manage');" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
             </div>
         </div>
     </div>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15860,6 +15860,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:1,
                     UserPalaceProject:1,
                     UserSideLoad:1,
+                    UserCloudLibrary:0,
+                    UserWebsite:0,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
@@ -15875,6 +15877,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:0,
                     UserPalaceProject:0,
                     UserSideLoad:0,
+                    UserCloudLibrary:0,
+                    UserWebsite:0,
                 };
             }
             $('.stripPopup').hide();
@@ -15923,6 +15927,8 @@ AspenDiscovery.CookieConsent = (function() {
                 UserOverdrive:0,
                 UserPalaceProject:0,
                 UserSideLoad:0,
+                UserCloudLibrary:0,
+                UserWebsite:0,
             };
             var params =  {
                 cookieEssential: cookieString['Essential'],
@@ -15937,6 +15943,8 @@ AspenDiscovery.CookieConsent = (function() {
                 cookieUserOverdrive: cookieString['UserOverdrive'],
                 cookieUserPalaceProject: cookieString['UserPalaceProject'],
                 cookieUserSideLoad: cookieString['UserSideLoad'],
+                cookieUserCloudLibrary: cookieString['UserCloudLibrary'],
+                cookieUserWebsite: cookieString['UserWebsite'],
 			};
             $.getJSON(url, params,
                 function(data) {
@@ -15966,6 +15974,8 @@ AspenDiscovery.CookieConsent = (function() {
             var cookieUserOverdrive = $('#cookieUserOverdrive').is(':checked') ? 1 : 0;
             var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
             var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
+            var cookieUserCloudLibrary = $('#cookieUserCloudLibrary').is(':checked') ? 1 : 0;
+            var cookieUserWebsite = $('#cookieUserWebsite').is(':checked') ? 1 : 0;
 
             formData.push({name: 'cookieEssential', value: cookieEssential});
             formData.push({name: 'cookieAnalytics', value: cookieAnalytics});
@@ -15979,6 +15989,8 @@ AspenDiscovery.CookieConsent = (function() {
             formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
             formData.push({name: 'cookieUserPalaceProject', value: cookieUserPalaceProject});
             formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
+            formData.push({name: 'cookieUserCloudLibrary', value: cookieUserCloudLibrary});
+            formData.push({name: 'cookieUserWebsite', value: cookieUserWebsite});
              var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 
        $.getJSON(url, formData,

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -14849,6 +14849,7 @@ AspenDiscovery.SideLoads = (function(){
 }(AspenDiscovery.SideLoads || {}));
 AspenDiscovery.Summon = (function(){
 	return {
+<<<<<<< HEAD
 		getSummonResults: function(searchTerm){
 			var url = Globals.path + "/Search/AJAX";
 			var params = "method=getSummonResults&searchTerm=" + encodeURIComponent(searchTerm);
@@ -14867,6 +14868,9 @@ AspenDiscovery.Summon = (function(){
 			});
 		},
 		trackSummonUsage: function (id) {
+=======
+		trackSummonUsage: function(id) {
+>>>>>>> 3fbc7d2c5 (fix: Fix tracking of summon usage)
 			var ajaxUrl = Globals.path + "/Summon/JSON?method=trackSummonUsage&id=" + id;
 			$.getJSON(ajaxUrl);
 		}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -14849,28 +14849,7 @@ AspenDiscovery.SideLoads = (function(){
 }(AspenDiscovery.SideLoads || {}));
 AspenDiscovery.Summon = (function(){
 	return {
-<<<<<<< HEAD
-		getSummonResults: function(searchTerm){
-			var url = Globals.path + "/Search/AJAX";
-			var params = "method=getSummonResults&searchTerm=" + encodeURIComponent(searchTerm);
-			var fullUrl = url + "?" + params;
-			$.ajax({
-				url: fullUrl,
-				dataType:"json",
-				success: function(data) {
-					var searchResults = data.formattedResults;
-					if (searchResults) {
-						if (searchResults.length > 0){
-							$("#summonSearchResultsPlaceholder").html(searchResults);
-						}
-					}
-				}
-			});
-		},
-		trackSummonUsage: function (id) {
-=======
 		trackSummonUsage: function(id) {
->>>>>>> 3fbc7d2c5 (fix: Fix tracking of summon usage)
 			var ajaxUrl = Globals.path + "/Summon/JSON?method=trackSummonUsage&id=" + id;
 			$.getJSON(ajaxUrl);
 		}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -14865,8 +14865,12 @@ AspenDiscovery.Summon = (function(){
 					}
 				}
 			});
+		},
+		trackSummonUsage: function (id) {
+			var ajaxUrl = Globals.path + "/Summon/JSON?method=trackSummonUsage&id=" + id;
+			$.getJSON(ajaxUrl);
 		}
-	}
+	};
 }(AspenDiscovery.Summon || {}));
 /**
  * Create a title scroller object for display

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15851,12 +15851,30 @@ AspenDiscovery.CookieConsent = (function() {
                     Essential:1,
                     Analytics:1,
                     UserAxis360:1,
+                    UserEbscoEds:1,
+                    UserEbscoHost:1,
+                    UserSummon:1,
+                    UserEvents:1,
+                    UserHoopla:1,
+                    UserOpenArchives:1,
+                    UserOverdrive:1,
+                    UserPalaceProject:1,
+                    UserSideLoad:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
                     Essential:1,
                     Analytics:0,
                     UserAxis360:0,
+                    UserEbscoEds:0,
+                    UserEbscoHost:0,
+                    UserSummon:0,
+                    UserEvents:0,
+                    UserHoopla:0,
+                    UserOpenArchives:0,
+                    UserOverdrive:0,
+                    UserPalaceProject:0,
+                    UserSideLoad:0,
                 };
             }
             $('.stripPopup').hide();
@@ -15896,12 +15914,29 @@ AspenDiscovery.CookieConsent = (function() {
                 Essential:1,
                 Analytics:0,
                 UserAxis360:0,
+                UserEbscoEds:0,
+                UserEbscoHost:0,
+                UserSummon:0,
+                UserEvents:0,
+                UserHoopla:0,
+                UserOpenArchives:0,
+                UserOverdrive:0,
+                UserPalaceProject:0,
+                UserSideLoad:0,
             };
             var params =  {
                 cookieEssential: cookieString['Essential'],
                 cookieAnalytics: cookieString['Analytics'],
                 cookieUserAxis360: cookieString['UserAxis360'],
-
+                cookieUserEbscoEds: cookieString['UserEbscoEds'],
+                cookieUserEbscoHost: cookieString['UserEbscoHost'],
+                cookieUserSummon: cookieString['UserSummon'],
+                cookieUserEvents: cookieString['UserEvents'],
+                cookieUserHoopla: cookieString['UserHoopla'],
+                cookieUserOpenArchives: cookieString['UserOpenArchives'],
+                cookieUserOverdrive: cookieString['UserOverdrive'],
+                cookieUserPalaceProject: cookieString['UserPalaceProject'],
+                cookieUserSideLoad: cookieString['UserSideLoad'],
 			};
             $.getJSON(url, params,
                 function(data) {
@@ -15920,8 +15955,27 @@ AspenDiscovery.CookieConsent = (function() {
             console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
             var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
+            var cookieUserEbscoEds = $('#cookieUserEbscoEds').is(':checked') ? 1 : 0;
+            var cookieUserEbscoHost = $('#cookieUserEbscoHost').is(':checked') ? 1 : 0;
+            var cookieUserSummon = $('#cookieUserSummon').is(':checked') ? 1 : 0;
+            var cookieUserEvents = $('#cookieUserEvents').is(':checked') ? 1 : 0;
+            var cookieUserHoopla = $('#cookieUserHoopla').is(':checked') ? 1 : 0;
+            var cookieUserOpenArchives = $('#cookieUserOpenArchives').is(':checked') ? 1 : 0;
+            var cookieUserOverdrive = $('#cookieUserOverdrive').is(':checked') ? 1 : 0;
+            var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
+            var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
+
             formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
-       var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
+            formData.push({name: 'cookieUserEbscoEds', value: cookieUserEbscoEds });
+            formData.push({name: 'cookieUserEbscoHost', value: cookieUserEbscoHost});
+            formData.push({name: 'cookieUserSummon', value: cookieUserSummon});
+            formData.push({name: 'cookieUserEvents', value: cookieUserEvents});
+            formData.push({name: 'cookieUserHoopla', value: cookieUserHoopla});
+            formData.push({name: 'cookieUserOpenArchives', value: cookieUserOpenArchives});
+            formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
+            formData.push({name: 'cookieUserPalaceproject', value: cookieUserPalaceProject});
+            formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
+             var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 
        $.getJSON(url, formData,
          function(data) {

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15950,6 +15950,7 @@ AspenDiscovery.CookieConsent = (function() {
                 function(data) {
                     if(data.success){
                         AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
+                        $('.stripPopup').hide();
                     } else {
                         AspenDiscovery.showMessage("There was an error retreiving your cookie preference options");
                     }
@@ -15958,7 +15959,6 @@ AspenDiscovery.CookieConsent = (function() {
             return false;
         },
         cookieManagementPreferences: function() {
-            console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
             var cookieEssential = $('#cookieEssential').is(':checked') ? 1 : 0;
             var cookieAnalytics = $('#cookieAnalytics').is(':checked') ? 1 : 0;
@@ -15993,7 +15993,6 @@ AspenDiscovery.CookieConsent = (function() {
 
        $.getJSON(url, formData,
          function(data) {
-            console.log('LAST DATA:', data);
             if(data.success) {
                 AspenDiscovery.showMessage(data.message);
             } else {

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15849,12 +15849,14 @@ AspenDiscovery.CookieConsent = (function() {
             if (props == 'all') {
                 var cookieString = {
                     Essential:1,
-                    Analytics:1
+                    Analytics:1,
+                    UserAxis360:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
                     Essential:1,
-                    Analytics:0
+                    Analytics:0,
+                    UserAxis360:0,
                 };
             }
             $('.stripPopup').hide();
@@ -15888,6 +15890,51 @@ AspenDiscovery.CookieConsent = (function() {
             AspenDiscovery.showMessage("Cookie Policy", Globals.cookiePolicyHTML);
             return;
         },
+        cookieManage: function() {
+            var url = Globals.path + "/AJAX/JSON?method=manageCookiePreferences";
+            var cookieString = {
+                Essential:1,
+                Analytics:0,
+                UserAxis360:0,
+            };
+            var params =  {
+                cookieEssential: cookieString['Essential'],
+                cookieAnalytics: cookieString['Analytics'],
+                cookieUserAxis360: cookieString['UserAxis360'],
+
+			};
+            $.getJSON(url, params,
+                function(data) {
+                    console.log('data success:', data.success);
+                    console.log('DATA:', data);
+                    if(data.success){
+                        AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
+                    } else {
+                        AspenDiscovery.showMessage("There was an error retreiving your cookie preference options");
+                    }
+                }
+             ).fail(AspenDiscovery.ajaxFail);
+            return false;
+        },
+        cookieManagementPreferences: function() {
+            console.log('LAST FUNCTION');
+            var formData = $('#cookieManagementPreferencesForm').serializeArray();
+            var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
+            formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
+       var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
+
+       $.getJSON(url, formData,
+         function(data) {
+            console.log('LAST DATA:', data);
+            if(data.success) {
+                AspenDiscovery.showMessage(data.message);
+            } else {
+                AspenDiscovery.showMessage("There was an error updating your cookie management preferences");
+            }
+         }
+        ).fail(AspenDiscovery.ajaxFail);
+        return false;
+       },
         fetchUserCookie: function(Values) {
             document.cookie = 'cookieConsent' + '=' + encodeURIComponent(Values) + ';  path=/';
             return;

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15954,6 +15954,8 @@ AspenDiscovery.CookieConsent = (function() {
         cookieManagementPreferences: function() {
             console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
+            var cookieEssential = $('#cookieEssential').is(':checked') ? 1 : 0;
+            var cookieAnalytics = $('#cookieAnalytics').is(':checked') ? 1 : 0;
             var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
             var cookieUserEbscoEds = $('#cookieUserEbscoEds').is(':checked') ? 1 : 0;
             var cookieUserEbscoHost = $('#cookieUserEbscoHost').is(':checked') ? 1 : 0;
@@ -15965,6 +15967,8 @@ AspenDiscovery.CookieConsent = (function() {
             var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
             var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
 
+            formData.push({name: 'cookieEssential', value: cookieEssential});
+            formData.push({name: 'cookieAnalytics', value: cookieAnalytics});
             formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
             formData.push({name: 'cookieUserEbscoEds', value: cookieUserEbscoEds });
             formData.push({name: 'cookieUserEbscoHost', value: cookieUserEbscoHost});
@@ -15973,7 +15977,7 @@ AspenDiscovery.CookieConsent = (function() {
             formData.push({name: 'cookieUserHoopla', value: cookieUserHoopla});
             formData.push({name: 'cookieUserOpenArchives', value: cookieUserOpenArchives});
             formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
-            formData.push({name: 'cookieUserPalaceproject', value: cookieUserPalaceProject});
+            formData.push({name: 'cookieUserPalaceProject', value: cookieUserPalaceProject});
             formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
              var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15860,8 +15860,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:1,
                     UserPalaceProject:1,
                     UserSideLoad:1,
-                    UserCloudLibrary:0,
-                    UserWebsite:0,
+                    UserCloudLibrary:1,
+                    UserWebsite:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
@@ -15948,8 +15948,6 @@ AspenDiscovery.CookieConsent = (function() {
 			};
             $.getJSON(url, params,
                 function(data) {
-                    console.log('data success:', data.success);
-                    console.log('DATA:', data);
                     if(data.success){
                         AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
                     } else {

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -109,6 +109,8 @@ AspenDiscovery.CookieConsent = (function() {
         cookieManagementPreferences: function() {
             console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
+            var cookieEssential = $('#cookieEssential').is(':checked') ? 1 : 0;
+            var cookieAnalytics = $('#cookieAnalytics').is(':checked') ? 1 : 0;
             var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
             var cookieUserEbscoEds = $('#cookieUserEbscoEds').is(':checked') ? 1 : 0;
             var cookieUserEbscoHost = $('#cookieUserEbscoHost').is(':checked') ? 1 : 0;
@@ -120,6 +122,8 @@ AspenDiscovery.CookieConsent = (function() {
             var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
             var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
 
+            formData.push({name: 'cookieEssential', value: cookieEssential});
+            formData.push({name: 'cookieAnalytics', value: cookieAnalytics});
             formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
             formData.push({name: 'cookieUserEbscoEds', value: cookieUserEbscoEds });
             formData.push({name: 'cookieUserEbscoHost', value: cookieUserEbscoHost});
@@ -128,7 +132,7 @@ AspenDiscovery.CookieConsent = (function() {
             formData.push({name: 'cookieUserHoopla', value: cookieUserHoopla});
             formData.push({name: 'cookieUserOpenArchives', value: cookieUserOpenArchives});
             formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
-            formData.push({name: 'cookieUserPalaceproject', value: cookieUserPalaceProject});
+            formData.push({name: 'cookieUserPalaceProject', value: cookieUserPalaceProject});
             formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
              var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -15,8 +15,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:1,
                     UserPalaceProject:1,
                     UserSideLoad:1,
-                    UserCloudLibrary:0,
-                    UserWebsite:0,
+                    UserCloudLibrary:1,
+                    UserWebsite:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -15,6 +15,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:1,
                     UserPalaceProject:1,
                     UserSideLoad:1,
+                    UserCloudLibrary:0,
+                    UserWebsite:0,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
@@ -30,6 +32,8 @@ AspenDiscovery.CookieConsent = (function() {
                     UserOverdrive:0,
                     UserPalaceProject:0,
                     UserSideLoad:0,
+                    UserCloudLibrary:0,
+                    UserWebsite:0,
                 };
             }
             $('.stripPopup').hide();
@@ -78,6 +82,8 @@ AspenDiscovery.CookieConsent = (function() {
                 UserOverdrive:0,
                 UserPalaceProject:0,
                 UserSideLoad:0,
+                UserCloudLibrary:0,
+                UserWebsite:0,
             };
             var params =  {
                 cookieEssential: cookieString['Essential'],
@@ -92,6 +98,8 @@ AspenDiscovery.CookieConsent = (function() {
                 cookieUserOverdrive: cookieString['UserOverdrive'],
                 cookieUserPalaceProject: cookieString['UserPalaceProject'],
                 cookieUserSideLoad: cookieString['UserSideLoad'],
+                cookieUserCloudLibrary: cookieString['UserCloudLibrary'],
+                cookieUserWebsite: cookieString['UserWebsite'],
 			};
             $.getJSON(url, params,
                 function(data) {
@@ -121,6 +129,8 @@ AspenDiscovery.CookieConsent = (function() {
             var cookieUserOverdrive = $('#cookieUserOverdrive').is(':checked') ? 1 : 0;
             var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
             var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
+            var cookieUserCloudLibrary = $('#cookieUserCloudLibrary').is(':checked') ? 1 : 0;
+            var cookieUserWebsite = $('#cookieUserWebsite').is(':checked') ? 1 : 0;
 
             formData.push({name: 'cookieEssential', value: cookieEssential});
             formData.push({name: 'cookieAnalytics', value: cookieAnalytics});
@@ -134,6 +144,8 @@ AspenDiscovery.CookieConsent = (function() {
             formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
             formData.push({name: 'cookieUserPalaceProject', value: cookieUserPalaceProject});
             formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
+            formData.push({name: 'cookieUserCloudLibrary', value: cookieUserCloudLibrary});
+            formData.push({name: 'cookieUserWebsite', value: cookieUserWebsite});
              var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 
        $.getJSON(url, formData,

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -76,7 +76,7 @@ AspenDiscovery.CookieConsent = (function() {
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
             var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
             formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
-       var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
+             var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 
        $.getJSON(url, formData,
          function(data) {

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -6,12 +6,30 @@ AspenDiscovery.CookieConsent = (function() {
                     Essential:1,
                     Analytics:1,
                     UserAxis360:1,
+                    UserEbscoEds:1,
+                    UserEbscoHost:1,
+                    UserSummon:1,
+                    UserEvents:1,
+                    UserHoopla:1,
+                    UserOpenArchives:1,
+                    UserOverdrive:1,
+                    UserPalaceProject:1,
+                    UserSideLoad:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
                     Essential:1,
                     Analytics:0,
                     UserAxis360:0,
+                    UserEbscoEds:0,
+                    UserEbscoHost:0,
+                    UserSummon:0,
+                    UserEvents:0,
+                    UserHoopla:0,
+                    UserOpenArchives:0,
+                    UserOverdrive:0,
+                    UserPalaceProject:0,
+                    UserSideLoad:0,
                 };
             }
             $('.stripPopup').hide();
@@ -51,12 +69,29 @@ AspenDiscovery.CookieConsent = (function() {
                 Essential:1,
                 Analytics:0,
                 UserAxis360:0,
+                UserEbscoEds:0,
+                UserEbscoHost:0,
+                UserSummon:0,
+                UserEvents:0,
+                UserHoopla:0,
+                UserOpenArchives:0,
+                UserOverdrive:0,
+                UserPalaceProject:0,
+                UserSideLoad:0,
             };
             var params =  {
                 cookieEssential: cookieString['Essential'],
                 cookieAnalytics: cookieString['Analytics'],
                 cookieUserAxis360: cookieString['UserAxis360'],
-
+                cookieUserEbscoEds: cookieString['UserEbscoEds'],
+                cookieUserEbscoHost: cookieString['UserEbscoHost'],
+                cookieUserSummon: cookieString['UserSummon'],
+                cookieUserEvents: cookieString['UserEvents'],
+                cookieUserHoopla: cookieString['UserHoopla'],
+                cookieUserOpenArchives: cookieString['UserOpenArchives'],
+                cookieUserOverdrive: cookieString['UserOverdrive'],
+                cookieUserPalaceProject: cookieString['UserPalaceProject'],
+                cookieUserSideLoad: cookieString['UserSideLoad'],
 			};
             $.getJSON(url, params,
                 function(data) {
@@ -75,7 +110,26 @@ AspenDiscovery.CookieConsent = (function() {
             console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
             var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
+            var cookieUserEbscoEds = $('#cookieUserEbscoEds').is(':checked') ? 1 : 0;
+            var cookieUserEbscoHost = $('#cookieUserEbscoHost').is(':checked') ? 1 : 0;
+            var cookieUserSummon = $('#cookieUserSummon').is(':checked') ? 1 : 0;
+            var cookieUserEvents = $('#cookieUserEvents').is(':checked') ? 1 : 0;
+            var cookieUserHoopla = $('#cookieUserHoopla').is(':checked') ? 1 : 0;
+            var cookieUserOpenArchives = $('#cookieUserOpenArchives').is(':checked') ? 1 : 0;
+            var cookieUserOverdrive = $('#cookieUserOverdrive').is(':checked') ? 1 : 0;
+            var cookieUserPalaceProject = $('#cookieUserPalaceProject').is(':checked') ? 1 : 0;
+            var cookieUserSideLoad = $('#cookieUserSideLoad').is(':checked') ? 1 : 0;
+
             formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
+            formData.push({name: 'cookieUserEbscoEds', value: cookieUserEbscoEds });
+            formData.push({name: 'cookieUserEbscoHost', value: cookieUserEbscoHost});
+            formData.push({name: 'cookieUserSummon', value: cookieUserSummon});
+            formData.push({name: 'cookieUserEvents', value: cookieUserEvents});
+            formData.push({name: 'cookieUserHoopla', value: cookieUserHoopla});
+            formData.push({name: 'cookieUserOpenArchives', value: cookieUserOpenArchives});
+            formData.push({name: 'cookieUserOverdrive', value: cookieUserOverdrive});
+            formData.push({name: 'cookieUserPalaceproject', value: cookieUserPalaceProject});
+            formData.push({name: 'cookieUserSideLoad', value: cookieUserSideLoad});
              var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
 
        $.getJSON(url, formData,

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -103,8 +103,6 @@ AspenDiscovery.CookieConsent = (function() {
 			};
             $.getJSON(url, params,
                 function(data) {
-                    console.log('data success:', data.success);
-                    console.log('DATA:', data);
                     if(data.success){
                         AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
                     } else {

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -105,6 +105,7 @@ AspenDiscovery.CookieConsent = (function() {
                 function(data) {
                     if(data.success){
                         AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
+                        $('.stripPopup').hide();
                     } else {
                         AspenDiscovery.showMessage("There was an error retreiving your cookie preference options");
                     }
@@ -113,7 +114,6 @@ AspenDiscovery.CookieConsent = (function() {
             return false;
         },
         cookieManagementPreferences: function() {
-            console.log('LAST FUNCTION');
             var formData = $('#cookieManagementPreferencesForm').serializeArray();
             var cookieEssential = $('#cookieEssential').is(':checked') ? 1 : 0;
             var cookieAnalytics = $('#cookieAnalytics').is(':checked') ? 1 : 0;
@@ -148,7 +148,6 @@ AspenDiscovery.CookieConsent = (function() {
 
        $.getJSON(url, formData,
          function(data) {
-            console.log('LAST DATA:', data);
             if(data.success) {
                 AspenDiscovery.showMessage(data.message);
             } else {

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -4,12 +4,14 @@ AspenDiscovery.CookieConsent = (function() {
             if (props == 'all') {
                 var cookieString = {
                     Essential:1,
-                    Analytics:1
+                    Analytics:1,
+                    UserAxis360:1,
                 };
             } else if (props == 'essential') {
                 var cookieString = {
                     Essential:1,
-                    Analytics:0
+                    Analytics:0,
+                    UserAxis360:0,
                 };
             }
             $('.stripPopup').hide();
@@ -43,6 +45,51 @@ AspenDiscovery.CookieConsent = (function() {
             AspenDiscovery.showMessage("Cookie Policy", Globals.cookiePolicyHTML);
             return;
         },
+        cookieManage: function() {
+            var url = Globals.path + "/AJAX/JSON?method=manageCookiePreferences";
+            var cookieString = {
+                Essential:1,
+                Analytics:0,
+                UserAxis360:0,
+            };
+            var params =  {
+                cookieEssential: cookieString['Essential'],
+                cookieAnalytics: cookieString['Analytics'],
+                cookieUserAxis360: cookieString['UserAxis360'],
+
+			};
+            $.getJSON(url, params,
+                function(data) {
+                    console.log('data success:', data.success);
+                    console.log('DATA:', data);
+                    if(data.success){
+                        AspenDiscovery.showMessage("Manage Your Cookie Preferences", data.modalBody);
+                    } else {
+                        AspenDiscovery.showMessage("There was an error retreiving your cookie preference options");
+                    }
+                }
+             ).fail(AspenDiscovery.ajaxFail);
+            return false;
+        },
+        cookieManagementPreferences: function() {
+            console.log('LAST FUNCTION');
+            var formData = $('#cookieManagementPreferencesForm').serializeArray();
+            var cookieUserAxis360 = $('#cookieUserAxis360').is(':checked') ? 1 : 0;
+            formData.push({name: 'cookieUserAxis360', value: cookieUserAxis360});
+       var url = Globals.path + "/AJAX/JSON?method=saveCookieManagementPreferences";
+
+       $.getJSON(url, formData,
+         function(data) {
+            console.log('LAST DATA:', data);
+            if(data.success) {
+                AspenDiscovery.showMessage(data.message);
+            } else {
+                AspenDiscovery.showMessage("There was an error updating your cookie management preferences");
+            }
+         }
+        ).fail(AspenDiscovery.ajaxFail);
+        return false;
+       },
         fetchUserCookie: function(Values) {
             document.cookie = 'cookieConsent' + '=' + encodeURIComponent(Values) + ';  path=/';
             return;

--- a/code/web/interface/themes/responsive/js/aspen/summon.js
+++ b/code/web/interface/themes/responsive/js/aspen/summon.js
@@ -1,23 +1,6 @@
 AspenDiscovery.Summon = (function(){
 	return {
-		getSummonResults: function(searchTerm){
-			var url = Globals.path + "/Search/AJAX";
-			var params = "method=getSummonResults&searchTerm=" + encodeURIComponent(searchTerm);
-			var fullUrl = url + "?" + params;
-			$.ajax({
-				url: fullUrl,
-				dataType:"json",
-				success: function(data) {
-					var searchResults = data.formattedResults;
-					if (searchResults) {
-						if (searchResults.length > 0){
-							$("#summonSearchResultsPlaceholder").html(searchResults);
-						}
-					}
-				}
-			});
-		},
-		trackSummonUsage: function (id) {
+		trackSummonUsage: function(id) {
 			var ajaxUrl = Globals.path + "/Summon/JSON?method=trackSummonUsage&id=" + id;
 			$.getJSON(ajaxUrl);
 		}

--- a/code/web/interface/themes/responsive/js/aspen/summon.js
+++ b/code/web/interface/themes/responsive/js/aspen/summon.js
@@ -16,6 +16,10 @@ AspenDiscovery.Summon = (function(){
 					}
 				}
 			});
+		},
+		trackSummonUsage: function (id) {
+			var ajaxUrl = Globals.path + "/Summon/JSON?method=trackSummonUsage&id=" + id;
+			$.getJSON(ajaxUrl);
 		}
-	}
+	};
 }(AspenDiscovery.Summon || {}));

--- a/code/web/release_notes/24.07.00.MD
+++ b/code/web/release_notes/24.07.00.MD
@@ -85,18 +85,14 @@
 - Properly expand sections when searching within settings. (*MDN*) 
 - Fixed a bug where if a user did not have a Cloud Library account it could falsely return a successful checkout message. (*KK*)
 - In offline mode, don't show buttons like Add a Review and Add to List that prompt a login. (Ticket 132443) (*KP*)
-- 'Return to List' returns submissions from the correct custom form or quick poll and the submissions page now prompts users to pick a form/poll. (Ticket 118583) (*KP*)
-- 'Old PIN provided is incorrect' message is now translatable. (Ticket 123151) (*KP*)
-- Added a new feature: SMTP setting. This allows for SMTP configuration to be utilized when sending e-mails from Aspen. (*PA*)
-- Split Greenhouse systems alerts into a separate Slack channel. (*KP*)
-- Update JavaScript for backwards compatibility with older browsers. (*MDN*) 
-- Delete old tables in the database while initializing the database for unit test. (*MDN*)
-- Add a utility to generate a site template to aid in migrating servers. (*MDN*)
-- Update updateSitePermissions scripts to include all directories. (*MDN*)
-- Increase column length for format in user_hold table to accommodate concatenated OverDrive/Libby formats (Ticket 134832) (*KL*)
-- Correct the number of requests made on the success screen after submitting a request. (Ticket 128760) (*MDN*)
-- Set limits for Aspen user within Debian. (*MDN*) 
-- Add the ability to change the supporting company name on site creation. (*CZ*)
+
+// alexander
+
+// jacob
+
+// pedro
+
+// other
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -18,6 +18,9 @@
 - Fixed bug with unexpected 404 errors on Web Builder pages.  (Ticket 123122) (*KP*)
 
 // alexander
+- Added option to manage which cookies are consented to . 
+- Added checklist on modal for cookie consent options. 
+- Added checks prior to user usage tracking for cookie storage consent settings and whether the user has consented to the tracking of their usage of the particualr module. 
 
 // jacob
 

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -646,6 +646,15 @@ class AJAX_JSON extends Action {
 		if (UserAccount::isLoggedIn()) {
 			$userObj = UserAccount::getActiveUserObj();
 			$userObj->userCookiePreferenceAxis360 = $_REQUEST['cookieUserAxis360'] == "1"  || $_REQUEST['cookieUserAxis360'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceEbscoEds = $_REQUEST['cookieUserEbscoEds'] == "1" || $_REQUEST['cookieUserEbscoEds'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceEbscoHost = $_REQUEST['cookieUserEbscoHost'] == "1" || $_REQUEST['cookieUserEbscoHost'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceSummon = $_REQUEST['cookieUserSummon'] == "1" || $_REQUEST['cookieUserSummon'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceEvents = $_REQUEST['cookieUserEvents'] == "1" || $_REQUEST['cookieUserEvents'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceHoopla = $_REQUEST['cookieUserHoopla'] == "1" || $_REQUEST['cookieUserHoopla'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceOpenArchives = $_REQUEST['cookieUserOpenArchives'] == "1" || $_REQUEST['cookieUserOpenArchives'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceOverdrive = $_REQUEST['cookieUserOverdrive'] == "1" || $_REQUEST['cookieUserOverdrive'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferencePalaceProject = $_REQUEST['cookieUserPalaceProject'] == "1" || $_REQUEST['cookieUserPalaceProject'] == 1 ? 1 :0;
+			$userObj->userCookiePreferenceSideLoad = $_REQUEST['cookieUserSideLoad'] == "1" || $_REQUEST['cookieUserSideLoad'] == 1 ? 1 : 0;
 			$userObj->update();
 			return[
 				'success' => true,
@@ -654,7 +663,17 @@ class AJAX_JSON extends Action {
 		} else {
 			$userCookiePost = [
 				'Essential' => 1,
-				'UserAxis360' => isset($_POST['cookieUserAxis360']) ? 1 : 0
+				'Analytics' => $_REQUEST['cookieAnalytics'],
+				'UserAxis360' => isset($_POST['cookieUserAxis360']) ? 1 : 0,
+				'UserEbscoEds' => isset($_POST['cookieUserEbscoEds']) ? 1 : 0,
+				'UserEbscoHost' => isset($_POST['cookieUserEbscoHost']) ? 1 : 0,
+				'UserSummon' => isset($_POST['cookieUserSummon']) ? 1: 0,
+				'UserEvents' => isset($_POST['cookieUserEvents']) ? 1 : 0,
+				'UserHoopla' => isset($_POST['cookieUserHoopla']) ? 1 : 0,
+				'UserOpenArchives' => isset($_POST['cookieUserOpenArchives']) ? 1 : 0,
+				'UserOverdrive' => isset($_POST['cookieUserOverdrive']) ? 1 : 0,
+				'UserPalaceProject' => isset($_POST['cookieUserPalaceProject']) ? 1 : 0,
+				'UserSideLoad' => isset($_POST['cookieUserSideLoad']) ? 1 : 0,
 			];
 			setcookie('cookieConsent', json_encode($userCookiePost), 0, '/');
 			return [

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -645,6 +645,8 @@ class AJAX_JSON extends Action {
 	function saveCookieManagementPreferences() {
 		if (UserAccount::isLoggedIn()) {
 			$userObj = UserAccount::getActiveUserObj();
+			$userObj->userCookiePreferenceEssential = $_REQUEST['cookieEssential'] == "1" || $_REQUEST['cookieEssential'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceAnalytics = $_REQUEST['cookieAnalytics'] == "1" || $_REQUEST['cookieAnalytics'] == 1 ? 1 : 0;
 			$userObj->userCookiePreferenceAxis360 = $_REQUEST['cookieUserAxis360'] == "1"  || $_REQUEST['cookieUserAxis360'] == 1 ? 1 : 0;
 			$userObj->userCookiePreferenceEbscoEds = $_REQUEST['cookieUserEbscoEds'] == "1" || $_REQUEST['cookieUserEbscoEds'] == 1 ? 1 : 0;
 			$userObj->userCookiePreferenceEbscoHost = $_REQUEST['cookieUserEbscoHost'] == "1" || $_REQUEST['cookieUserEbscoHost'] == 1 ? 1 : 0;

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -25,7 +25,9 @@ class AJAX_JSON extends Action {
 				'saveCookiePreference',
 				'deleteTranslationTerm',
 				'getDisplaySettingsForm',
-				'updateDisplaySettings'
+				'updateDisplaySettings',
+				'manageCookiePreferences',
+				'saveCookieManagementPreferences',
 			])) {
 				$output = json_encode($this->$method());
 				// Browser-side handler ajaxLightbox() doesn't use the input format in else block below
@@ -631,6 +633,60 @@ class AJAX_JSON extends Action {
 			]),
 		];
 	}
+
+	function manageCookiePreferences(){
+		global $interface;
+		return [
+			'success' => true,
+			'modalBody' => $interface->fetch('AJAX/cookieManagement.tpl'),
+		];
+	}
+
+	// function saveCookieManagementPreferences() {
+	// 	$response = [];
+
+	// 	if (UserAccount::isLoggedIn()) {
+	// 		$userObj = UserAccount::getActiveUserObj();
+	// 		$userObj->userCookiePreferenceAxis360 = $_REQUEST['cookieUserAxis360'];
+	// 		$userObj->update();
+	// 		return [
+	// 			'success' => true,
+	// 			'message' => 'Your preferences were updated.  You can make changes to these preferences within your account settings.',
+	// 		];
+	// 	} else {
+	// 		$userCookiePost = [
+	// 			'Essential' =>1,
+	// 			'UserAxis360' => $_REQUEST['cookieUserAxis360'],
+	// 		];
+	// 		setCookie('cookieConsent', json_encode($userCookiePost), 0, '/');
+	// 		return [
+	// 			'success' => true,
+	// 		];
+	// 	}
+	// }
+
+	function saveCookieManagementPreferences() {
+		if (UserAccount::isLoggedIn()) {
+			$userObj = UserAccount::getActiveUserObj();
+			$userObj->userCookiePreferenceAxis360 = $_REQUEST['cookieUserAxis360'] == "1"  || $_REQUEST['cookieUserAxis360'] == 1 ? 1 : 0;
+			$userObj->update();
+			return[
+				'success' => true,
+				'message' => 'Your preferences were updated.  You can make changes to these preferences within your account settings.',
+			];
+		} else {
+			$userCookiePost = [
+				'Essential' => 1,
+				'UserAxis360' => isset($_POST['cookieUserAxis360']) ? 1 : 0
+			];
+			setcookie('cookieConsent', json_encode($userCookiePost), 0, '/');
+			return [
+				'success' => true,
+				'message' => '',
+			];
+		}
+	}
+	
 
 	function getBreadcrumbs(): array {
 		return [];

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -657,6 +657,8 @@ class AJAX_JSON extends Action {
 			$userObj->userCookiePreferenceOverdrive = $_REQUEST['cookieUserOverdrive'] == "1" || $_REQUEST['cookieUserOverdrive'] == 1 ? 1 : 0;
 			$userObj->userCookiePreferencePalaceProject = $_REQUEST['cookieUserPalaceProject'] == "1" || $_REQUEST['cookieUserPalaceProject'] == 1 ? 1 :0;
 			$userObj->userCookiePreferenceSideLoad = $_REQUEST['cookieUserSideLoad'] == "1" || $_REQUEST['cookieUserSideLoad'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceCloudLibrary = $_REQUEST['cookieUserCloudLibrary'] == "1" || $_REQUEST['cookieUserCloudLibrary'] == 1 ? 1 : 0;
+			$userObj->userCookiePreferenceWebsite = $_REQUEST['cookieUserWebsite'] == "1" || $_REQUEST['cookieUserWebsite'] == 1 ? 1 : 0;
 			$userObj->update();
 			return[
 				'success' => true,
@@ -676,6 +678,8 @@ class AJAX_JSON extends Action {
 				'UserOverdrive' => isset($_POST['cookieUserOverdrive']) ? 1 : 0,
 				'UserPalaceProject' => isset($_POST['cookieUserPalaceProject']) ? 1 : 0,
 				'UserSideLoad' => isset($_POST['cookieUserSideLoad']) ? 1 : 0,
+				'UserCloudLibrary' => isset($_POST['cookieUserCloudLibrary']) ? 1 : 0,
+				'UserWebsite' => isset($_POST['cookieUserWebsite']) ? 1 : 0,
 			];
 			setcookie('cookieConsent', json_encode($userCookiePost), 0, '/');
 			return [

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -642,29 +642,6 @@ class AJAX_JSON extends Action {
 		];
 	}
 
-	// function saveCookieManagementPreferences() {
-	// 	$response = [];
-
-	// 	if (UserAccount::isLoggedIn()) {
-	// 		$userObj = UserAccount::getActiveUserObj();
-	// 		$userObj->userCookiePreferenceAxis360 = $_REQUEST['cookieUserAxis360'];
-	// 		$userObj->update();
-	// 		return [
-	// 			'success' => true,
-	// 			'message' => 'Your preferences were updated.  You can make changes to these preferences within your account settings.',
-	// 		];
-	// 	} else {
-	// 		$userCookiePost = [
-	// 			'Essential' =>1,
-	// 			'UserAxis360' => $_REQUEST['cookieUserAxis360'],
-	// 		];
-	// 		setCookie('cookieConsent', json_encode($userCookiePost), 0, '/');
-	// 		return [
-	// 			'success' => true,
-	// 		];
-	// 	}
-	// }
-
 	function saveCookieManagementPreferences() {
 		if (UserAccount::isLoggedIn()) {
 			$userObj = UserAccount::getActiveUserObj();

--- a/code/web/services/EBSCO/JSON.php
+++ b/code/web/services/EBSCO/JSON.php
@@ -43,6 +43,7 @@ class EBSCO_JSON extends JSON_Action {
 
 	/** @noinspection PhpUnused */
 	public function trackEdsUsage(): array {
+		global $library;
 		if (!isset($_REQUEST['id'])) {
 			return [
 				'success' => false,
@@ -71,25 +72,30 @@ class EBSCO_JSON extends JSON_Action {
 			$ebscoEdsRecordUsage->insert();
 		}
 
-		$userId = UserAccount::getActiveUserId();
-		if ($userId) {
-			//Track usage for the user
-			require_once ROOT_DIR . '/sys/Ebsco/UserEbscoEdsUsage.php';
-			$userEbscoEdsUsage = new UserEbscoEdsUsage();
-			global $aspenUsage;
-			$userEbscoEdsUsage->instance = $aspenUsage->getInstance();
-			$userEbscoEdsUsage->userId = $userId;
-			$userEbscoEdsUsage->year = date('Y');
-			$userEbscoEdsUsage->month = date('n');
+		$userObj = UserAccount::getActiveUserObj();
+		$userEbscoTracking = $userObj->userCookiePreferenceEbscoEds;
 
-			if ($userEbscoEdsUsage->find(true)) {
-				$userEbscoEdsUsage->usageCount++;
-				$userEbscoEdsUsage->update();
-			} else {
-				$userEbscoEdsUsage->usageCount = 1;
-				$userEbscoEdsUsage->insert();
+		if ($userEbscoTracking && $library->cookieStorageConsent) {
+			$userId = UserAccount::getActiveUserId();
+			if ($userId) {
+				//Track usage for the user
+				require_once ROOT_DIR . '/sys/Ebsco/UserEbscoEdsUsage.php';
+				$userEbscoEdsUsage = new UserEbscoEdsUsage();
+				global $aspenUsage;
+				$userEbscoEdsUsage->instance = $aspenUsage->getInstance();
+				$userEbscoEdsUsage->userId = $userId;
+				$userEbscoEdsUsage->year = date('Y');
+				$userEbscoEdsUsage->month = date('n');
+
+				if ($userEbscoEdsUsage->find(true)) {
+					$userEbscoEdsUsage->usageCount++;
+					$userEbscoEdsUsage->update();
+				} else {
+					$userEbscoEdsUsage->usageCount = 1;
+					$userEbscoEdsUsage->insert();
+				}
 			}
-		}
+		} 
 
 		return [
 			'success' => true,

--- a/code/web/services/Greenhouse/ExportAspenData.php
+++ b/code/web/services/Greenhouse/ExportAspenData.php
@@ -154,7 +154,7 @@ class Greenhouse_ExportAspenData extends Admin_Admin {
 				'name' => 'Summon Record Usage',
 			],
 			'user_summon_usage' => [
-				'classFile' => ROOT_DIR . '/sys/Ebsco/UserSummonUsage.php',
+				'classFile' => ROOT_DIR . '/sys/Summon/UserSummonUsage.php',
 				'className' => 'UserSummonUsage',
 				'name' => 'User Summon Usage',
 			],

--- a/code/web/services/MyAccount/MyCookiePreferences.php
+++ b/code/web/services/MyAccount/MyCookiePreferences.php
@@ -1,0 +1,108 @@
+<?php
+
+require_once ROOT_DIR . '/services/MyAccount/MyAccount.php';
+
+class MyAccount_MyCookiePreferences extends MyAccount {
+    function launch() {
+        global $interface;
+        $user = UserAccount::getLoggedInUser();
+
+        if ($user) {
+            // Determine which user we are showing/updating settings for
+			$linkedUsers = $user->getLinkedUsers();
+			$patronId = isset($_REQUEST['patronId']) ? $_REQUEST['patronId'] : $user->id;
+			/** @var User $patron */
+			$patron = $user->getUserReferredTo($patronId);
+
+           // Linked Accounts Selection Form set-up
+			if (count($linkedUsers) > 0) {
+				array_unshift($linkedUsers, $user); // Adds primary account to list for display in account selector
+				$interface->assign('linkedUsers', $linkedUsers);
+				$interface->assign('selectedUser', $patronId);
+			}
+
+            global $librarySingleton;
+            // Save/Update Actions
+			global $offlineMode;
+			if (isset($_POST['updateScope']) && !$offlineMode) {
+				$samePatron = true;
+				if ($_REQUEST['patronId'] != $user->id){
+					$samePatron = false;
+				}
+				if ($samePatron){
+					$cookieResult = $this->updateUserCookiePreferences($patron);
+					if (isset($cookieResult['message'])) {
+						$user->updateMessage .= ' ' . $cookieResult['message'];
+					}
+					$user->updateMessageIsError = $user->updateMessageIsError || $cookieResult['success'];
+				}else{
+					$user->updateMessage = translate([
+						'text' => 'Wrong account credentials, please try again.',
+						'isPublicFacing' => true,
+					]);
+					$user->updateMessageIsError = true;
+				}
+				$user->update();
+
+				session_write_close();
+				$actionUrl = '/MyAccount/MyCookiePreferences' . ($patronId == $user->id ? '' : '?patronId=' . $patronId); // redirect after form submit completion
+				header("Location: " . $actionUrl);
+				exit();
+			} elseif (!$offlineMode) {
+				$interface->assign('edit', true);
+			} else {
+				$interface->assign('edit', false);
+			}
+
+			global $library;
+			$interface->assign('cookieConsentEnabled', $library->cookieStorageConsent);
+
+			if (!empty($user->updateMessage)) {
+				if ($user->updateMessageIsError) {
+					$interface->assign('profileUpdateErrors', $user->updateMessage);
+				} else {
+					$interface->assign('profileUpdateMessage', $user->updateMessage);
+				}
+				$user->updateMessage = '';
+				$user->updateMessageIsError = 0;
+				$user->update();
+			}
+		}
+
+		$this->display('myCookiePreferences.tpl', 'My Preferences');
+	}
+
+    function updateUserCookiePreferences($patron) {
+		$success = true;
+		$message = ' ';
+		$patron->userCookiePreferenceEssential = 1; // Essential cookies are always enabled
+        $patron->userCookiePreferenceAnalytics = isset($_POST['userCookieAnalytics']) ? 1 : 0;
+        $patron->userCookiePreferenceAxis360 = isset($_POST['userCookieUserAxis360']) ? 1 : 0;
+        $patron->userCookiePreferenceEbscoEds = isset($_POST['userCookieUserEbscoEds']) ? 1 : 0;
+        $patron->userCookiePreferenceEbscoHost = isset($_POST['userCookieUserEbscoHost']) ? 1 : 0;
+        $patron->userCookiePreferenceSummon = isset($_POST['userCookieUserSummon']) ? 1 : 0;
+        $patron->userCookiePreferenceEvents = isset($_POST['userCookieUserEvents']) ? 1 : 0;
+        $patron->userCookiePreferenceHoopla = isset($_POST['userCookieUserHoopla']) ? 1 : 0;
+        $patron->userCookiePreferenceOpenArchives = isset($_POST['userCookieUserOpenArchives']) ? 1 : 0;
+        $patron->userCookiePreferenceOverdrive = isset($_POST['userCookieUserOverdrive']) ? 1 : 0;
+        $patron->userCookiePreferencePalaceProject = isset($_POST['userCookieUserPalaceProject']) ? 1 : 0;
+        $patron->userCookiePreferenceSideLoad = isset($_POST['userCookieUserSideLoad']) ? 1 : 0;
+		$patron->userCookiePreferenceCloudLibrary = isset($_POST['userCookieUserCloudLibrary']) ? 1 : 0;
+		$patron->userCookiePreferenceWebsite = isset($_POST['userCookieUserWebsite']) ? 1 : 0;
+
+        if (!$patron->update()) {
+            $success = false;
+            $message = 'Failed to update cookie preferences.';
+        }
+
+        return ['success' => $success, 'message' => $message];
+
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/MyAccount/Home', 'Your Account');
+		$breadcrumbs[] = new Breadcrumb('', 'Your Preferences');
+		return $breadcrumbs;
+	}
+}

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -77,20 +77,14 @@ class MyAccount_MyPreferences extends MyAccount {
 					}
 					$user->updateMessageIsError = !$result['success'];
 
-					$cookieResult = $this->updateUserCookiePreferences($patron);
-					if (isset($cookieResult['message'])) {
-						$user->updateMessage .= ' ' . $cookieResult['message'];
+					if ($canUpdateContactInfo && $allowHomeLibraryUpdates) {
+						$result2 = $user->updateHomeLibrary($_REQUEST['homeLocation']);
+						if (!empty($user->updateMessage)) {
+							$user->updateMessage .= '<br/>';
+						}
+						$user->updateMessage .= implode('<br/>', $result2['messages']);
+						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
 					}
-					$user->updateMessageIsError = $user->updateMessageIsError || $cookieResult['success'];
-
-					// if ($canUpdateContactInfo && $allowHomeLibraryUpdates) {
-					// 	$result2 = $user->updateHomeLibrary($_REQUEST['homeLocation']);
-					// 	if (!empty($user->updateMessage)) {
-					// 		$user->updateMessage .= '<br/>';
-					// 	}
-					// 	$user->updateMessage .= implode('<br/>', $result2['messages']);
-					// 	$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
-					// }
 				}else{
 					$user->updateMessage = translate([
 						'text' => 'Wrong account credentials, please try again.',
@@ -153,32 +147,6 @@ class MyAccount_MyPreferences extends MyAccount {
 		$this->display('myPreferences.tpl', 'My Preferences');
 	}
 
-	function updateUserCookiePreferences($patron) {
-		$siccess = true;
-		$message = ' ';
-		$patron->userCookiePreferenceEssential = 1; // Essential cookies are always enabled
-        $patron->userCookiePreferenceAnalytics = isset($_POST['userCookieAnalytics']) ? 1 : 0;
-        $patron->userCookiePreferenceAxis360 = isset($_POST['userCookieUserAxis360']) ? 1 : 0;
-        $patron->userCookiePreferenceEbscoEds = isset($_POST['userCookieUserEbscoEds']) ? 1 : 0;
-        $patron->userCookiePreferenceEbscoHost = isset($_POST['userCookieUserEbscoHost']) ? 1 : 0;
-        $patron->userCookiePreferenceSummon = isset($_POST['userCookieUserSummon']) ? 1 : 0;
-        $patron->userCookiePreferenceEvents = isset($_POST['userCookieUserEvents']) ? 1 : 0;
-        $patron->userCookiePreferenceHoopla = isset($_POST['userCookieUserHoopla']) ? 1 : 0;
-        $patron->userCookiePreferenceOpenArchives = isset($_POST['userCookieUserOpenArchives']) ? 1 : 0;
-        $patron->userCookiePreferenceOverdrive = isset($_POST['userCookieUserOverdrive']) ? 1 : 0;
-        $patron->userCookiePreferencePalaceProject = isset($_POST['userCookieUserPalaceProject']) ? 1 : 0;
-        $patron->userCookiePreferenceSideLoad = isset($_POST['userCookieUserSideLoad']) ? 1 : 0;
-		$patron->userCookiePreferenceCloudLibrary = isset($_POST['userCookieUserCloudLibrary']) ? 1 : 0;
-		$patron->userCookiePreferenceWebsite = isset($_POST['userCookieUserWebsite']) ? 1 : 0;
-
-        if (!$patron->update()) {
-            $success = false;
-            $message = 'Failed to update cookie preferences.';
-        }
-
-        return ['success' => $success, 'message' => $message];
-
-	}
 
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -168,6 +168,8 @@ class MyAccount_MyPreferences extends MyAccount {
         $patron->userCookiePreferenceOverdrive = isset($_POST['userCookieUserOverdrive']) ? 1 : 0;
         $patron->userCookiePreferencePalaceProject = isset($_POST['userCookieUserPalaceProject']) ? 1 : 0;
         $patron->userCookiePreferenceSideLoad = isset($_POST['userCookieUserSideLoad']) ? 1 : 0;
+		$patron->userCookiePreferenceCloudLibrary = isset($_POST['userCookieUserCloudLibrary']) ? 1 : 0;
+		$patron->userCookiePreferenceWebsite = isset($_POST['userCookieUserWebsite']) ? 1 : 0;
 
         if (!$patron->update()) {
             $success = false;

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -85,9 +85,6 @@ class MyAccount_MyPreferences extends MyAccount {
 						$user->updateMessage .= implode('<br/>', $result2['messages']);
 						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
 					}
-					if(isset($_POST['userCookieUserAxis360'])) {
-						$user->userCookiePreferenceAxis360 = isset($_POST['userCookiePreferenceAxis360']) ? 1 : 0;
-					}
 				}else{
 					$user->updateMessage = translate([
 						'text' => 'Wrong account credentials, please try again.',

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -77,14 +77,20 @@ class MyAccount_MyPreferences extends MyAccount {
 					}
 					$user->updateMessageIsError = !$result['success'];
 
-					if ($canUpdateContactInfo && $allowHomeLibraryUpdates) {
-						$result2 = $user->updateHomeLibrary($_REQUEST['homeLocation']);
-						if (!empty($user->updateMessage)) {
-							$user->updateMessage .= '<br/>';
-						}
-						$user->updateMessage .= implode('<br/>', $result2['messages']);
-						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+					$cookieResult = $this->updateUserCookiePreferences($patron);
+					if (isset($cookieResult['message'])) {
+						$user->updateMessage .= ' ' . $cookieResult['message'];
 					}
+					$user->updateMessageIsError = $user->updateMessageIsError || $cookieResult['success'];
+
+					// if ($canUpdateContactInfo && $allowHomeLibraryUpdates) {
+					// 	$result2 = $user->updateHomeLibrary($_REQUEST['homeLocation']);
+					// 	if (!empty($user->updateMessage)) {
+					// 		$user->updateMessage .= '<br/>';
+					// 	}
+					// 	$user->updateMessage .= implode('<br/>', $result2['messages']);
+					// 	$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+					// }
 				}else{
 					$user->updateMessage = translate([
 						'text' => 'Wrong account credentials, please try again.',
@@ -145,6 +151,31 @@ class MyAccount_MyPreferences extends MyAccount {
 		}
 
 		$this->display('myPreferences.tpl', 'My Preferences');
+	}
+
+	function updateUserCookiePreferences($patron) {
+		$siccess = true;
+		$message = ' ';
+		$patron->userCookiePreferenceEssential = 1; // Essential cookies are always enabled
+        $patron->userCookiePreferenceAnalytics = isset($_POST['userCookieAnalytics']) ? 1 : 0;
+        $patron->userCookiePreferenceAxis360 = isset($_POST['userCookieUserAxis360']) ? 1 : 0;
+        $patron->userCookiePreferenceEbscoEds = isset($_POST['userCookieUserEbscoEds']) ? 1 : 0;
+        $patron->userCookiePreferenceEbscoHost = isset($_POST['userCookieUserEbscoHost']) ? 1 : 0;
+        $patron->userCookiePreferenceSummon = isset($_POST['userCookieUserSummon']) ? 1 : 0;
+        $patron->userCookiePreferenceEvents = isset($_POST['userCookieUserEvents']) ? 1 : 0;
+        $patron->userCookiePreferenceHoopla = isset($_POST['userCookieUserHoopla']) ? 1 : 0;
+        $patron->userCookiePreferenceOpenArchives = isset($_POST['userCookieUserOpenArchives']) ? 1 : 0;
+        $patron->userCookiePreferenceOverdrive = isset($_POST['userCookieUserOverdrive']) ? 1 : 0;
+        $patron->userCookiePreferencePalaceProject = isset($_POST['userCookieUserPalaceProject']) ? 1 : 0;
+        $patron->userCookiePreferenceSideLoad = isset($_POST['userCookieUserSideLoad']) ? 1 : 0;
+
+        if (!$patron->update()) {
+            $success = false;
+            $message = 'Failed to update cookie preferences.';
+        }
+
+        return ['success' => $success, 'message' => $message];
+
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -85,6 +85,9 @@ class MyAccount_MyPreferences extends MyAccount {
 						$user->updateMessage .= implode('<br/>', $result2['messages']);
 						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
 					}
+					if(isset($_POST['userCookieUserAxis360'])) {
+						$user->userCookiePreferenceAxis360 = isset($_POST['userCookiePreferenceAxis360']) ? 1 : 0;
+					}
 				}else{
 					$user->updateMessage = translate([
 						'text' => 'Wrong account credentials, please try again.',

--- a/code/web/services/OpenArchives/JSON.php
+++ b/code/web/services/OpenArchives/JSON.php
@@ -25,7 +25,10 @@ class OpenArchives_JSON extends JSON_Action {
 		//Track usage of the record
 		require_once ROOT_DIR . '/sys/OpenArchives/OpenArchivesRecordUsage.php';
 		$openArchivesUsage = new OpenArchivesRecordUsage();
+		$userObj = UserAccount::getActiveUserObj();
+		$userOpenArchivesTracking = $userObj->userCookiePreferenceOpenArchives;
 		global $aspenUsage;
+		global $library;
 		$openArchivesUsage->instance = $aspenUsage->getInstance();
 		$openArchivesUsage->openArchivesRecordId = $id;
 		$openArchivesUsage->year = date('Y');
@@ -42,24 +45,28 @@ class OpenArchives_JSON extends JSON_Action {
 			$openArchivesUsage->insert();
 		}
 
-		$userId = UserAccount::getActiveUserId();
-		if ($userId) {
-			//Track usage for the user
-			require_once ROOT_DIR . '/sys/OpenArchives/UserOpenArchivesUsage.php';
-			$userOpenArchivesUsage = new UserOpenArchivesUsage();
-			global $aspenUsage;
-			$userOpenArchivesUsage->instance = $aspenUsage->getInstance();
-			$userOpenArchivesUsage->userId = $userId;
-			$userOpenArchivesUsage->year = date('Y');
-			$userOpenArchivesUsage->month = date('n');
-			$userOpenArchivesUsage->openArchivesCollectionId = $openArchivesRecord->sourceCollection;
+		if ($userOpenArchivesTracking && $library->cookieStorageConsent) {
 
-			if ($userOpenArchivesUsage->find(true)) {
-				$userOpenArchivesUsage->usageCount++;
-				$userOpenArchivesUsage->update();
-			} else {
-				$userOpenArchivesUsage->usageCount = 1;
-				$userOpenArchivesUsage->insert();
+		
+			$userId = UserAccount::getActiveUserId();
+			if ($userId) {
+				//Track usage for the user
+				require_once ROOT_DIR . '/sys/OpenArchives/UserOpenArchivesUsage.php';
+				$userOpenArchivesUsage = new UserOpenArchivesUsage();
+				global $aspenUsage;
+				$userOpenArchivesUsage->instance = $aspenUsage->getInstance();
+				$userOpenArchivesUsage->userId = $userId;
+				$userOpenArchivesUsage->year = date('Y');
+				$userOpenArchivesUsage->month = date('n');
+				$userOpenArchivesUsage->openArchivesCollectionId = $openArchivesRecord->sourceCollection;
+
+				if ($userOpenArchivesUsage->find(true)) {
+					$userOpenArchivesUsage->usageCount++;
+					$userOpenArchivesUsage->update();
+				} else {
+					$userOpenArchivesUsage->usageCount = 1;
+					$userOpenArchivesUsage->insert();
+				}
 			}
 		}
 

--- a/code/web/services/Record/AccessOnline.php
+++ b/code/web/services/Record/AccessOnline.php
@@ -92,7 +92,10 @@ class Record_AccessOnline extends Action {
 	public function trackUserUsageOfSideLoad(int $sideLoadId): void {
 		require_once ROOT_DIR . '/sys/Indexing/UserSideLoadUsage.php';
 		$userUsage = new UserSideLoadUsage();
+		$userObj = UserAccount::getActiveUserObj();
+		$userSideLoadTracking = $userObj->userCookiePreferenceSideLoad;
 		global $aspenUsage;
+		global $library;
 		$userUsage->instance = $aspenUsage->getInstance();
 		if (UserAccount::getActiveUserId() == false) {
 			//User is not logged in
@@ -104,12 +107,14 @@ class Record_AccessOnline extends Action {
 		$userUsage->year = date('Y');
 		$userUsage->month = date('n');
 
-		if ($userUsage->find(true)) {
-			$userUsage->usageCount++;
-			$userUsage->update();
-		} else {
-			$userUsage->usageCount = 1;
-			$userUsage->insert();
+		if ($userSideLoadTracking && $library->cookieStorageConsent) {
+			if ($userUsage->find(true)) {
+				$userUsage->usageCount++;
+				$userUsage->update();
+			} else {
+				$userUsage->usageCount = 1;
+				$userUsage->insert();
+			}
 		}
 	}
 

--- a/code/web/services/Summon/JSON.php
+++ b/code/web/services/Summon/JSON.php
@@ -4,7 +4,6 @@ require_once ROOT_DIR . '/JSON_Action.php';
 
 class Summon_JSON extends JSON_Action {
     /**@noinspection PhpUnused */
-    
     public function trackSummonUsage(): array {
 		global $library;
         if (!isset($_REQUEST['id'])) {

--- a/code/web/services/Summon/JSON.php
+++ b/code/web/services/Summon/JSON.php
@@ -15,8 +15,8 @@ class Summon_JSON extends JSON_Action {
         $id = $_REQUEST['id'];
 
         require_once ROOT_DIR . '/sys/Summon/SummonRecordUsage.php';
-        $summonRecordRecordUsage = new SummonRecordUsage();
-        global $asoenUsage;
+        $summonRecordUsage = new SummonRecordUsage();
+        global $aspenUsage;
         $summonRecordUsage->instance = $aspenUsage->getInstance();
         $summonRecordUsage->summonId = $id;
         $summonRecordUsage->year = date('Y');
@@ -37,19 +37,24 @@ class Summon_JSON extends JSON_Action {
 		if ($userId) {
 			//Track usage for the user
 			require_once ROOT_DIR . '/sys/Summon/UserSummonUsage.php';
+			$userObj = UserAccount::getActiveUserObj();
+			$userSummonTracking = $userObj->userCookiePreferenceSummon;
 			$userSummonUsage = new UserSummonUsage();
 			global $aspenUsage;
+			global $library;
 			$userSummonUsage->instance = $aspenUsage->getInstance();
 			$userSummonUsage->userId = $userId;
 			$userSummonUsage->year = date('Y');
 			$userSummonUsage->month = date('n');
 
-			if ($userSummonUsage->find(true)) {
-				$userSummonUsage->usageCount++;
-				$userSummonUsage->update();
-			} else {
-				$userSummonUsage->usageCount = 1;
-				$userSummonUsage->insert();
+			if ($userSummonTracking && $library->cookieStorageConsent) {
+				if ($userSummonUsage->find(true)) {
+					$userSummonUsage->usageCount++;
+					$userSummonUsage->update();
+				} else {
+					$userSummonUsage->usageCount = 1;
+					$userSummonUsage->insert();
+				}
 			}
 		}
 

--- a/code/web/services/Summon/JSON.php
+++ b/code/web/services/Summon/JSON.php
@@ -6,6 +6,7 @@ class Summon_JSON extends JSON_Action {
     /**@noinspection PhpUnused */
     
     public function trackSummonUsage(): array {
+		global $library;
         if (!isset($_REQUEST['id'])) {
             return [
                 'success' => false,
@@ -33,21 +34,21 @@ class Summon_JSON extends JSON_Action {
             $summonRecordUsage->insert();
         }
 
-        $userId = UserAccount::getActiveUserId();
-		if ($userId) {
-			//Track usage for the user
-			require_once ROOT_DIR . '/sys/Summon/UserSummonUsage.php';
-			$userObj = UserAccount::getActiveUserObj();
-			$userSummonTracking = $userObj->userCookiePreferenceSummon;
-			$userSummonUsage = new UserSummonUsage();
-			global $aspenUsage;
-			global $library;
-			$userSummonUsage->instance = $aspenUsage->getInstance();
-			$userSummonUsage->userId = $userId;
-			$userSummonUsage->year = date('Y');
-			$userSummonUsage->month = date('n');
+		$userObj = UserAccount::getActiveUserObj();
+		$userSummonTracking = $userObj->userCookiePreferenceSummon;
 
-			if ($userSummonTracking && $library->cookieStorageConsent) {
+		if ($userSummonTracking && $library->cookieStorageConsent) {
+			$userId = UserAccount::getActiveUserId();
+			if ($userId) {
+				//Track usage for the user
+				require_once ROOT_DIR . '/sys/Summon/UserSummonUsage.php';
+				$userSummonUsage = new UserSummonUsage();
+				global $aspenUsage;
+				$userSummonUsage->instance = $aspenUsage->getInstance();
+				$userSummonUsage->userId = $userId;
+				$userSummonUsage->year = date('Y');
+				$userSummonUsage->month = date('n');
+
 				if ($userSummonUsage->find(true)) {
 					$userSummonUsage->usageCount++;
 					$userSummonUsage->update();

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -59,6 +59,8 @@ class User extends DataObject {
 	public $userCookiePreferenceOverdrive;
 	public $userCookiePreferencePalaceProject;
 	public $userCookiePreferenceSideLoad;
+	public $userCookiePreferenceCloudLibrary;
+	public $userCookiePreferenceWebsite;
 	
 	public $holdInfoLastLoaded;
 	public $checkoutInfoLastLoaded;
@@ -1171,6 +1173,8 @@ class User extends DataObject {
 			$this->__set('userCookiePreferenceOverdrive', (isset($_POST['userCookieUserOverdrive']) && $_POST['userCookieUserOverdrive'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferencePalaceProject', (isset($_POST['userCookieUserPalaceProject']) && $_POST['userCookieUserPalaceProject'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceSideLoad', (isset($_POST['userCookieUserSideLoad']) && $_POST['userCookieUserSideLoad'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceCloudLibrary', (isset($_POST['userCookieUserCloudLibrary']) && $_POST['userCookieUserCloudLibrary'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceWebsite', (isset($_POST['userCookieUserWebsite']) && $_POST['userCookieUserWebsite'] == 'on') ? 1 : 0);
 		}
 
 		$this->__set('noPromptForUserReviews', (isset($_POST['noPromptForUserReviews']) && $_POST['noPromptForUserReviews'] == 'on') ? 1 : 0);

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -49,6 +49,7 @@ class User extends DataObject {
 	public $isLoggedInViaSSO;
 	public $userCookiePreferenceEssential;
 	public $userCookiePreferenceAnalytics;
+	public $userCookiePreferenceAxis360;
 
 	public $holdInfoLastLoaded;
 	public $checkoutInfoLastLoaded;
@@ -1152,6 +1153,7 @@ class User extends DataObject {
 			setcookie("cookieConsent", "", time() - 3600, "/"); //remove old cookie so new one can be generated on next page load
 			$this->__set('userCookiePreferenceEssential', 1);
 			$this->__set('userCookiePreferenceAnalytics', (isset($_POST['userCookieAnalytics']) && $_POST['userCookieAnalytics'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceAxis360', (isset($_POST['userCookieUserAxis360']) && $_POST['userCookieUserAxis360'] == 'on') ? 1 : 0);
 		}
 
 		$this->__set('noPromptForUserReviews', (isset($_POST['noPromptForUserReviews']) && $_POST['noPromptForUserReviews'] == 'on') ? 1 : 0);

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -50,7 +50,16 @@ class User extends DataObject {
 	public $userCookiePreferenceEssential;
 	public $userCookiePreferenceAnalytics;
 	public $userCookiePreferenceAxis360;
-
+	public $userCookiePreferenceEbscoEds;
+	public $userCookiePreferenceEbscoHost;
+	public $userCookiePreferenceSummon;
+	public $userCookiePreferenceEvents;
+	public $userCookiePreferenceHoopla;
+	public $userCookiePreferenceOpenArchives;
+	public $userCookiePreferenceOverdrive;
+	public $userCookiePreferencePalaceProject;
+	public $userCookiePreferenceSideLoad;
+	
 	public $holdInfoLastLoaded;
 	public $checkoutInfoLastLoaded;
 
@@ -1154,6 +1163,15 @@ class User extends DataObject {
 			$this->__set('userCookiePreferenceEssential', 1);
 			$this->__set('userCookiePreferenceAnalytics', (isset($_POST['userCookieAnalytics']) && $_POST['userCookieAnalytics'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceAxis360', (isset($_POST['userCookieUserAxis360']) && $_POST['userCookieUserAxis360'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceEbscoEds', (isset($_POST['userCookieUserEbscoEds']) && $_POST['userCookieUserEbscoEds'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceEbscoHost', (isset($_POST['userCookieUserEbscoHost']) && $_POST['userCookieUserEbscoHost'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceSummon', (isset($_POST['userCookieSummon']) && $_POST['userCookieSummon'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceEvents', (isset($_POST['userCookieEvents']) && $_POST['userCookieEvents'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceHoopla', (isset($_POST['userCookieUserHoopla']) && $_POST['userCookieUsrHoopla'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceOpenArchives', (isset($_POST['userCookieUserOpenArchives']) && $_POST['userCookieUserOpenArchives'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceOverdrive', (isset($_POST['userCookieUserOverdrive']) && $_POST['userCookieUserOverdrive'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferencePalaceProject', (isset($_POST['userCookieUserPalaceProject']) && $_POST['userCookieUserPalaceProject'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceSideLoad', (isset($_POST['userCookieUserSideLoad']) && $_POST['userCookieUserSideLoad'] == 'on') ? 1 : 0);
 		}
 
 		$this->__set('noPromptForUserReviews', (isset($_POST['noPromptForUserReviews']) && $_POST['noPromptForUserReviews'] == 'on') ? 1 : 0);

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1106,7 +1106,28 @@ class User extends DataObject {
 		if (isset($_REQUEST['preferredTheme'])) {
 			$this->__set('preferredTheme', $_REQUEST['preferredTheme']);
 		}
+		if (isset($_REQUEST['userCookieEssential'])) {
+			$this->__Set('userCookieEssential', $_REQUEST['userCookieEssential']);
+		}
+		// if (isset($_REQUEST['userCookieAnalytics'])) {
+		// 	$this->__set('userCookieAnalytics', $_REQUEST['userCookieAnalytics']);
+		// }
+		if (isset($_REQUEST['userCookieUserAxis360'])) {
+			$this->__set('userCookiePreferenceAxis360', $_REQUEST['userCookieUserAxis360']);
+		}
 
+		// if (isset($_REQUEST['userCookieUserAxis360'])) {
+		// 	$this->__set('userCookieUserAxis360', $_REQUEST['userCookieUserAxis360']);
+		// }
+		if (isset($_REQUEST['userCookieUserEbscoEds'])) {
+			$this->__set('userCookieUserEbscoEds', $_REQUEST['userCookieUserEbscoEds']);
+		}
+		if (isset($_REQUEST['userCookieUserEbscoHost'])) {
+			$this->__set('userCookieUserEbscoHost', $_REQUEST['userCookieUserEbscoHost']);
+		}
+		if (isset($_REQUEST['userCookieUserSummon'])) {
+			$this->__set('userCookieUserSummon', $_REQUEST['userCookieUserSummon']);
+		}
 		//Make sure the selected location codes are in the database.
 		if (isset($_POST['pickupLocation'])) {
 			if ($_POST['pickupLocation'] == 0) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1106,28 +1106,6 @@ class User extends DataObject {
 		if (isset($_REQUEST['preferredTheme'])) {
 			$this->__set('preferredTheme', $_REQUEST['preferredTheme']);
 		}
-		if (isset($_REQUEST['userCookieEssential'])) {
-			$this->__Set('userCookieEssential', $_REQUEST['userCookieEssential']);
-		}
-		// if (isset($_REQUEST['userCookieAnalytics'])) {
-		// 	$this->__set('userCookieAnalytics', $_REQUEST['userCookieAnalytics']);
-		// }
-		if (isset($_REQUEST['userCookieUserAxis360'])) {
-			$this->__set('userCookiePreferenceAxis360', $_REQUEST['userCookieUserAxis360']);
-		}
-
-		// if (isset($_REQUEST['userCookieUserAxis360'])) {
-		// 	$this->__set('userCookieUserAxis360', $_REQUEST['userCookieUserAxis360']);
-		// }
-		if (isset($_REQUEST['userCookieUserEbscoEds'])) {
-			$this->__set('userCookieUserEbscoEds', $_REQUEST['userCookieUserEbscoEds']);
-		}
-		if (isset($_REQUEST['userCookieUserEbscoHost'])) {
-			$this->__set('userCookieUserEbscoHost', $_REQUEST['userCookieUserEbscoHost']);
-		}
-		if (isset($_REQUEST['userCookieUserSummon'])) {
-			$this->__set('userCookieUserSummon', $_REQUEST['userCookieUserSummon']);
-		}
 		//Make sure the selected location codes are in the database.
 		if (isset($_POST['pickupLocation'])) {
 			if ($_POST['pickupLocation'] == 0) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1168,7 +1168,7 @@ class User extends DataObject {
 			$this->__set('userCookiePreferenceEbscoHost', (isset($_POST['userCookieUserEbscoHost']) && $_POST['userCookieUserEbscoHost'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceSummon', (isset($_POST['userCookieSummon']) && $_POST['userCookieSummon'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceEvents', (isset($_POST['userCookieEvents']) && $_POST['userCookieEvents'] == 'on') ? 1 : 0);
-			$this->__set('userCookiePreferenceHoopla', (isset($_POST['userCookieUserHoopla']) && $_POST['userCookieUsrHoopla'] == 'on') ? 1 : 0);
+			$this->__set('userCookiePreferenceHoopla', (isset($_POST['userCookieUserHoopla']) && $_POST['userCookieUserHoopla'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceOpenArchives', (isset($_POST['userCookieUserOpenArchives']) && $_POST['userCookieUserOpenArchives'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferenceOverdrive', (isset($_POST['userCookieUserOverdrive']) && $_POST['userCookieUserOverdrive'] == 'on') ? 1 : 0);
 			$this->__set('userCookiePreferencePalaceProject', (isset($_POST['userCookieUserPalaceProject']) && $_POST['userCookieUserPalaceProject'] == 'on') ? 1 : 0);

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -105,40 +105,6 @@ function getUpdates24_07_00(): array {
 
 
 		//alexander - PTFS Europe
-		'update_cookie_management_preferences' => [
-			'title' => 'Update Cookie Management Preferences',
-			'description' => 'Update cookie management preferences for user tracking',
-			'continueOnError' => false,
-			'sql' => [
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceAxis360 TINYINT(1) DEFAULT 0",
-			],
-		], //update_user_tracking_cookies
-		'update_cookie_management_preferences_more_options' => [
-			'title' => 'Update Cookie Management Preferences: More Options',
-			'description' => 'Update cookie management preferences for user tracking - adding more options',
-			'continueOnError' => false,
-			'sql' => [
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoEds TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoHost TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceSummon TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceEvents TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceHoopla TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceOpenArchives TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceOverdrive TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferencePalaceProject TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceSideLoad TINYINT(1) DEFAULT 0",
-			],
-		], //update_user_tracking_cookies
-		'add_cookie_management_preferences' => [
-			'title' => 'Cookie Management for Cloud Libray and Website',
-			'description' => 'Add Cookie Management preferences for website and cloud library',
-			'continueOnError' => false,
-			'sql' => [
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceCloudLibrary TINYINT(1) DEFAULT 0",
-				"ALTER TABLE user ADD COLUMN userCookiePreferenceWebsite TINYINT(1) DEFAULT 0",
-			],
-		], //add_user_tacking_cookie_preferences
-
 		//other
 
 

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -104,6 +104,16 @@ function getUpdates24_07_00(): array {
 		], //permissions_create_administer_smtp
 
 
+		//alexander - PTFS Europe
+		'update_cookie_management_preferences' => [
+			'title' => 'Update Cookie Management Preferences',
+			'description' => 'Update cookie management preferences for user tracking',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceAxis360 TINYINT(1) DEFAULT 0",
+			],
+		], //update_user_tracking_cookies
+
 		//other
 
 

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -129,6 +129,15 @@ function getUpdates24_07_00(): array {
 				"ALTER TABLE user ADD COLUMN userCookiePreferenceSideLoad TINYINT(1) DEFAULT 0",
 			],
 		], //update_user_tracking_cookies
+		'add_cookie_management_preferences' => [
+			'title' => 'Cookie Management for Cloud Libray and Website',
+			'description' => 'Add Cookie Management preferences for website and cloud library',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceCloudLibrary TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceWebsite TINYINT(1) DEFAULT 0",
+			],
+		], //add_user_tacking_cookie_preferences
 
 		//other
 

--- a/code/web/sys/DBMaintenance/version_updates/24.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.07.00.php
@@ -113,6 +113,22 @@ function getUpdates24_07_00(): array {
 				"ALTER TABLE user ADD COLUMN userCookiePreferenceAxis360 TINYINT(1) DEFAULT 0",
 			],
 		], //update_user_tracking_cookies
+		'update_cookie_management_preferences_more_options' => [
+			'title' => 'Update Cookie Management Preferences: More Options',
+			'description' => 'Update cookie management preferences for user tracking - adding more options',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoEds TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoHost TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceSummon TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEvents TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceHoopla TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceOpenArchives TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceOverdrive TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferencePalaceProject TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceSideLoad TINYINT(1) DEFAULT 0",
+			],
+		], //update_user_tracking_cookies
 
 		//other
 

--- a/code/web/sys/DBMaintenance/version_updates/24.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.08.00.php
@@ -21,6 +21,39 @@ function getUpdates24_08_00(): array {
 		//katherine - ByWater
 
 		//alexander - PTFS-Europe
+		'update_cookie_management_preferences' => [
+			'title' => 'Update Cookie Management Preferences',
+			'description' => 'Update cookie management preferences for user tracking',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceAxis360 TINYINT(1) DEFAULT 0",
+			],
+		], //update_user_tracking_cookies
+		'update_cookie_management_preferences_more_options' => [
+			'title' => 'Update Cookie Management Preferences: More Options',
+			'description' => 'Update cookie management preferences for user tracking - adding more options',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoEds TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEbscoHost TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceSummon TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceEvents TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceHoopla TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceOpenArchives TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceOverdrive TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferencePalaceProject TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceSideLoad TINYINT(1) DEFAULT 0",
+			],
+		], //update_user_tracking_cookies
+		'add_cookie_management_preferences' => [
+			'title' => 'Cookie Management for Cloud Libray and Website',
+			'description' => 'Add Cookie Management preferences for website and cloud library',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceCloudLibrary TINYINT(1) DEFAULT 0",
+				"ALTER TABLE user ADD COLUMN userCookiePreferenceWebsite TINYINT(1) DEFAULT 0",
+			],
+		], //add_user_tacking_cookie_preferences
 
 		//pedro - PTFS-Europe
 

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -666,6 +666,7 @@ class UInterface extends Smarty {
 		$this->assign('showUserCirculationModules', $library->showUserCirculationModules);
 		$this->assign('showUserContactInformation', $library->showUserContactInformation);
 		$this->assign('showUserPreferences', $library->showUserPreferences);
+		$this->assign('cookieConsentEnabled', $library->cookieStorageConsent);
 
 		if ($location != null) { // library and location
 			$groupedWorkDisplaySettings = $location->getGroupedWorkDisplaySettings();


### PR DESCRIPTION
Test Plan:
For the test plan we will test the cookie preferences against Summon. 
Note: If you have set these preferences before, navigate to your account -> your preferences and check that your summon cookie preferences are turned off when you first carry out steps 13 onwards. 

1. Apply patch
2. Navigate to Primary Configuration -> Library Systems -> and select your current library
3. Scroll down to 'Data protection Regulations' and check the box next to 'Require Cookie Storage Consent'
4.  Navigate to the Administration Menu
5. You may get a Cookie Consent Popup, if you do, you can ignore it or click 'Essential Only', if you have set your cookies before you may not get this pop up
6. Navigate to System Administration -> Modules
7. Scroll down to Summon, click edit and check the enable box. You can leave the other boxes blank. 
8. In the left hand menu, you should now have a section named Summon.  
9. Click on Summon -> Settings then select Add New.
10. Use the information in Passbolt to set up Summon and save. 
11. Using the administration menu, select Primary Configuration -> Library Systems and select edit for your current library
12. Scroll down to Summon and in the Summon Settings dropdown, select the name you gave your settings in step 10, then save. 
13. Carry out a Summon Search by selecting 'Articles and Databases' in the dropdown at the top of the page.
14. Click on one of the record returned. 
15. Check the db table: user_summon_usage and notice that it does not update.
16. Navigate to your account then in the Account Settings, select 'Your Preferences'.
17. Scroll down to 'Cookies to Allow' and turn Summon on then save. 
18. Repeat steps 13 - 15, but notice that this time the db table has updated. 

