### PR TITLE
fix: Add toolbar to Summon Results

### DIFF
--- a/code/web/interface/themes/responsive/Summon/list.tpl
+++ b/code/web/interface/themes/responsive/Summon/list.tpl
@@ -1,4 +1,4 @@
-<h1 class="hiddenTitle">{translate text='Events Search Results' isPublicFacing=true}</h1>
+<h1 class="hiddenTitle">{translate text='Articles & Databases Search Results'}</h1>
 <div id="searchInfo">
 	{* Recommendations *}
 	{if !empty($topRecommendations)}
@@ -7,9 +7,13 @@
 		{/foreach}
 	{/if}
 
-	{* Information about the search *}
 	<div class="result-head">
-
+		{* User's viewing mode toggle switch *}
+		{if !empty($showSearchToolsAtTop)}
+			{include file="Search/search-toolbar.tpl"}
+		{else}
+			{include file="Search/results-displayMode-toggle.tpl"}
+		{/if}
 		{if !empty($replacementTerm)}
 			<div id="replacement-search-info-block">
 				<div id="replacement-search-info"><span class="replacement-search-info-text">{translate text="Showing Results for" isPublicFacing=true}</span> {$replacementTerm}</div>
@@ -38,12 +42,8 @@
 			</div>
 		{/if}
 
-		{* User's viewing mode toggle switch *}
-		{include file="Events/results-displayMode-toggle.tpl"}
-
 		<div class="clearer"></div>
 	</div>
-	{* End Listing Options *}
 
 	{if !empty($subpage)}
 		{include file=$subpage}
@@ -51,39 +51,29 @@
 		{$pageContent}
 	{/if}
 
-	{if $displayMode == 'covers'}
-		{if $recordEnd < $recordCount}
-			<a onclick="return AspenDiscovery.Searches.getMoreResults()" role="button" title="{translate text='Get More Results' inAttribute=true isPublicFacing=true}">
-				<div class="row" id="more-browse-results">
-					<span class="glyphicon glyphicon-chevron-down" aria-label="{translate text='Get More Results' inAttribute=true isPublicFacing=true}" role="button"></span>
-				</div>
-			</a>
-		{/if}
-	{else}
-		{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
-	{/if}
+	{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
 
-	{if $showSearchTools || ($loggedIn && count($userPermissions) > 0)}
-	<div class="search_tools well small">
-		<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
-		{if !empty($showSearchTools) && (empty($offline) || $enableEContentWhileOffline)}
-			<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true);">{translate text='Email this Search' isPublicFacing=true}</a>
-			{if !empty($enableSavedSearches)}
-				{if !empty($savedSearch)}
-					<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
-				{else}
-					<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+	{if !empty($showSearchTools) && !$showSearchToolsAtTop}
+		<div class="search_tools well small">
+			<strong>{translate text='Search Tools' isPublicFacing=true} </strong>
+			<a href="{$rssLink|escape}">{translate text='Get RSS Feed' isPublicFacing=true}</a>
+			{if empty($offline) || $enableEContentWhileOffline}
+				<a href="#" onclick="return AspenDiscovery.Account.ajaxLightbox('/Search/AJAX?method=getEmailForm', true); ">{translate text='Email this Search' isPublicFacing=true}</a>
+				{if !empty($enableSavedSearches)}
+					{if !empty($savedSearch)}
+						<a href="/MyAccount/SaveSearch?delete={$searchId}">{translate text="Remove Saved Search" isPublicFacing=true}</a>
+					{else}
+						<a href="#" onclick="return AspenDiscovery.Account.showSaveSearchForm('{$searchId}')">{translate text='Save Search' isPublicFacing=true}</a>
+					{/if}
 				{/if}
 			{/if}
-			{*<a href="{$excelLink|escape}">{translate text='Export To CSV' isPublicFacing=true}</a>*}
-		{/if}
-		{if !empty($loggedIn) && (in_array('Administer All Collection Spotlights', $userPermissions) || in_array('Administer Library Collection Spotlights', $userPermissions))}
-			<a href="#" onclick="return AspenDiscovery.CollectionSpotlights.createSpotlightFromSearch('{$searchId}')">{translate text='Create Spotlight' isAdminFacing=true}</a>
-		{/if}
-		{if !empty($loggedIn) && (in_array('Administer All Browse Categories', $userPermissions) || in_array('Administer Library Browse Categories', $userPermissions) || in_array('Administer Selected Browse Category Groups', $userPermissions))}
-			<a href="#" onclick="return AspenDiscovery.Browse.addToHomePage('{$searchId}')">{translate text='Add To Browse' isPublicFacing=true}</a>
-		{/if}
-	</div>
+			{if !empty($loggedIn) && (in_array('Administer All Collection Spotlights', $userPermissions) || in_array('Administer Library Collection Spotlights', $userPermissions))}
+				<a href="#" onclick="return AspenDiscovery.CollectionSpotlights.createSpotlightFromSearch('{$searchId}')">{translate text='Create Spotlight' isAdminFacing=true}</a>
+			{/if}
+			{if !empty($loggedIn) && (in_array('Administer All Browse Categories', $userPermissions) || in_array('Administer Library Browse Categories', $userPermissions) || in_array('Administer Selected Browse Category Groups', $userPermissions))}
+				<a href="#" onclick="return AspenDiscovery.Browse.addToHomePage('{$searchId}')">{translate text='Add To Browse' isPublicFacing=true}</a>
+			{/if}
+		</div>
 	{/if}
 </div>
 
@@ -105,6 +95,5 @@
 			Globals.opac = 1; {* set to true to keep opac browsers from storing browse mode *}
 		{/if}
 		$('#'+AspenDiscovery.Searches.displayMode).parent('label').addClass('active'); {* show user which one is selected *}
-
 		{rdelim});
 </script>


### PR DESCRIPTION
Test Plan: 
1. Before applying patch, set up Summon and carry out a search. 
2. Notice that there is no checkbox to hide covers or option to switch between list and covers view at the top of the page. 
3. Repeat the above with an Ebsco EDS search. 
4. Apply the patch. 
5. Notice that when you carry out a Summon Search now, the search tools are at the top of the screen as they are in Ebsco EDS. 
6. NOTE: The checkbox for show covers has an effect but the view remains the same whether you select list or covers, this is in keeping with the EBSCO EDS actions. 