### PR TITLE
Where is it button renders consistently

### DIFF
--- a/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
@@ -32,7 +32,7 @@
 		{/if}
 		{if empty($inPopUp)}
 			{assign var=numRemainingCopies value=$totalCopies-$numDefaultItems}
-			{if $numRemainingCopies > 0 || ($showQuickCopy == 2 || $showQuickCopy == 3)}
+			{if $numRemainingCopies > 0 || ($showQuickCopy == 1 || $showQuickCopy == 2 || $showQuickCopy == 3)}
 				{if $showQuickCopy == 1 || $showQuickCopy == 2 || $showQuickCopy == 3}
 					{if $totalCopies > 0}
 						<div class="itemSummary">

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -21,6 +21,10 @@
 // lucas
 
 // James Staub
+
+// Chloe 
+- Fixed bug preventing the where_is_it button from rendering consistently on search results with available copies. (*CZ*)
+
 ### Reports
 - Nashville-specific: Circulation Holds Report now includes item-level holds (*JStaub*)
 
@@ -40,6 +44,7 @@
   - Pedro Amorim (PA)
   - Alexander Blanchard (AB)
   - Jacob O'Mara (JOM)
+  - Chloe Zermatten (CZ)
 
 - Theke Solutions
   - Lucas Montoya (LM)


### PR DESCRIPTION
**Description:** 

Search results for which there are one or more copies available in one or more locations should all include a 'Where is it' button. With the current behaviour, the button only display for some of the search results which meet this criteria. This PR resolves this by updating the check in copySummary.tpl to include one additional condition.  

**Test plan:** 

To replicate the bug:

- Run a search (keep the criteria field empty)
- Look through the search result: some results that have available copies at certain locations will display a 'Where is it?' button, whilst other won't

To test the fix: 

- Apply the patch
- Run a search (keep the criteria field empty)
- Look through the search result: all results that have available copies at certain locations should now display a 'Where is it?' button