### PR TITLE
New createKeyFile.php cron script

### DIFF
--- a/code/web/cron/createKeyFile.php
+++ b/code/web/cron/createKeyFile.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../bootstrap.php';
+
+global $serverName;
+
+$passkeyFile = ROOT_DIR . "/../../sites/$serverName/conf/passkey";
+if (!file_exists($passkeyFile)) {
+    // Return the file path (note that all ini files are in the conf/ directory)
+    $methods = [
+        'aes-256-gcm',
+        'aes-128-gcm',
+    ];
+    foreach ($methods as $cipher) {
+        if (in_array($cipher, openssl_get_cipher_methods())) {
+            //Generate a 32 character password which will encode to 64 characters in hex notation
+            $key = bin2hex(openssl_random_pseudo_bytes(32));
+            break;
+        }
+    }
+    $passkeyFhnd = fopen($passkeyFile, 'w');
+    fwrite($passkeyFhnd, $cipher . ':' . $key);
+    fclose($passkeyFhnd);
+
+    //Make sure the file is not readable by anyone except the aspen user
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        $runningOnWindows = true;
+    } else {
+        $runningOnWindows = false;
+    }
+    if (!$runningOnWindows) {
+        exec('chown aspen:aspen_apache ' . $passkeyFile);
+        exec('chmod 440 ' . $passkeyFile);
+    }
+}

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -17,6 +17,11 @@
 // jacob
 
 // pedro
+- Updated the way the passkey file is generated. (*PA*)
+
+To generate the passkey file, the following command should be run (as root):
+
+`php /usr/local/aspen-discovery/code/web/cron/createKeyFile.php <serverName>`
 
 // lucas
 

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -571,40 +571,6 @@ class SystemAPI extends AbstractAPI {
 		return $availableUpdates;
 	}
 
-	/** @noinspection PhpUnused */
-	function createKeyFile() {
-		global $serverName;
-		$passkeyFile = ROOT_DIR . "/../../sites/$serverName/conf/passkey";
-		if (!file_exists($passkeyFile)) {
-			// Return the file path (note that all ini files are in the conf/ directory)
-			$methods = [
-				'aes-256-gcm',
-				'aes-128-gcm',
-			];
-			foreach ($methods as $cipher) {
-				if (in_array($cipher, openssl_get_cipher_methods())) {
-					//Generate a 32 character password which will encode to 64 characters in hex notation
-					$key = bin2hex(openssl_random_pseudo_bytes(32));
-					break;
-				}
-			}
-			$passkeyFhnd = fopen($passkeyFile, 'w');
-			fwrite($passkeyFhnd, $cipher . ':' . $key);
-			fclose($passkeyFhnd);
-
-			//Make sure the file is not readable by anyone except the aspen user
-			if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-				$runningOnWindows = true;
-			} else {
-				$runningOnWindows = false;
-			}
-			if (!$runningOnWindows) {
-				exec('chown aspen:aspen_apache ' . $passkeyFile);
-				exec('chmod 440 ' . $passkeyFile);
-			}
-		}
-	}
-
 	function doesKeyFileExist() {
 		global $serverName;
 		$passkeyFile = ROOT_DIR . "/../../sites/$serverName/conf/passkey";


### PR DESCRIPTION
This PR aims to make sure the generated passkey file has the inteded ownership and permissions. 

Test plan, adb, before applying branch:
1) Run the following curl to generate a passkey file:
curl -k http://localhost/API/SystemAPI?method=createKeyFile  --resolve 'test.localhostaspen:80:127.0.0.1'
2) Notice a new passkey file now exists at
/usr/local/aspen-discovery/sites/test.localhostaspen/conf
3) Run ls -la at that dir and notice this passkey file is owned by www-data:www-data (this is wrong)
4) Remove this passkey:
rm /usr/local/aspen-discovery/sites/test.localhostaspen/conf/passkey

5) Apply branch
6) Generate a new passkey using the new script file:
php /usr/local/aspen-discovery/code/web/cron/createKeyFile.php test.localhostaspen
7) Repeat 2 and 3 but notice it now belongs to aspen:aspen_apache