### PR TITLE
Toggle display location in search facets

### DIFF
--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -100,6 +100,10 @@ To generate the passkey file, the following command should be run (as root):
 
 // other
 
+// chloe
+### Other Updates
+- Adds a new setting to Location(branch) which enables admins to toggle the visibility of specific branches under the 'Available At' search facet.
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -113,6 +117,7 @@ To generate the passkey file, the following command should be run (as root):
 - PTFS-Europe
   - Pedro Amorim (PA)
   - Alexander Blanchard (AB)
+  - Chloe Zermatten (CZ)
   - Jacob O'Mara (JOM)
 
 - Theke Solutions

--- a/code/web/sys/DBMaintenance/version_updates/24.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.08.00.php
@@ -100,6 +100,25 @@ function getUpdates24_08_00(): array {
 			]
 		], //web_builder_custom_form_increase_email
 
+		//James Staub - Nashville Public Library
+		'web_builder_custom_form_increase_email' => [
+			'title' => 'Increase Web Builder Custom Form "Email Results To" field character limit.',
+			'description' => 'Increase Web Builder Custom Form "Email Results To" field character limit.',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE web_builder_custom_form MODIFY COLUMN emailResultsTo VARCHAR(150)",
+			]
+		], //web_builder_custom_form_increase_email
+
+		//chloe - PTFS-Europe
+		'show_in_search_facet_column' => [
+			'title' => 'Show In Search Facet Column',
+			'description' => 'Adds the showInSearchFacet column to the Location table',
+			// 'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE location ADD COLUMN showInSearchFacet TINYINT(1) DEFAULT 1'
+			]
+			], //show_in_search_facet_column
 		//other
 
 	];

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -893,6 +893,15 @@ class Location extends DataObject {
 								'forcesReindex' => true,
 							],
 							[
+								'property' => 'showInSearchFacet',
+								'type' => 'checkbox',
+								'label' => 'Show This Branch In Search Facet',
+								'description' => 'Whether or not the library should appear as a location that can be selected to filter search results by.',
+								'hideInLists' => true,
+								'default' => true,
+								'forcesReindex' => true,
+							],
+							[
 								'property' => 'additionalLocationsToShowAvailabilityFor',
 								'type' => 'text',
 								'label' => 'Additional Locations to Include in Available At Facet',

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -899,7 +899,7 @@ class Location extends DataObject {
 								'description' => 'Whether or not the library should appear as a location that can be selected to filter search results by.',
 								'hideInLists' => true,
 								'default' => true,
-								'forcesReindex' => true,
+								'forcesReindex' => false,
 							],
 							[
 								'property' => 'additionalLocationsToShowAvailabilityFor',

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -45,6 +45,7 @@ class Location extends DataObject {
 	public $createSearchInterface;
 	public $showInSelectInterface;
 	public $showOnDonationsPage;
+	public $showInSearchFacet;
 	public $enableAppAccess;
 	public $appReleaseChannel;
 	public $theme;

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -785,6 +785,19 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			$numValidLibraries = 0;
 			// Loop through values:
 			$isScopedField = $this->isScopedField($field);
+
+			// Get a list of branches so we can access their 'showInSearchFacet' value
+			// Also rename the keys to the branches' names so they can easily be accessed later
+			$branchList = null;
+			if ($field == 'available_at') {
+				$mainBranch = new Location();
+				$branchList = $mainBranch->getLocationListAsObjects(false);
+				// may need to be optimised / unsure how heavy this is
+				foreach ($branchList as $key=>$value) {
+					$branchList[$value->displayName] = $value;
+					unset($branchList[$key]);
+				}
+			}
 			foreach ($data as $facet) {
 				// Initialize the array of data about the current facet:
 				$currentSettings = [];

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -789,7 +789,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			// Get a list of branches so we can access their 'showInSearchFacet' value
 			// Also rename the keys to the branches' names so they can easily be accessed later
 			$branchList = null;
-			if ($field == 'available_at') {
+			if ($field == 'available_at' || $field == 'owning_location') {
 				$mainBranch = new Location();
 				$branchList = $mainBranch->getLocationListAsObjects(false);
 				// may need to be optimised / unsure how heavy this is
@@ -806,7 +806,7 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				// if populating the array of facet options for 'available at'
 				// then filter out any branch (location) for which showInSearchFacet has been set to "0"
 				// thus preventing these branches from being displayed as search by options
-				if ($field == 'available_at') {
+				if ($field == 'available_at' || $field == 'owning_location') {
 					$branchName = substr($facetValue, 5);
 					if (empty($branchList[$branchName]->showInSearchFacet)) {
 						continue;

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -802,6 +802,17 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 				// Initialize the array of data about the current facet:
 				$currentSettings = [];
 				$facetValue = $facet[0];
+				
+				// if populating the array of facet options for 'available at'
+				// then filter out any branch (location) for which showInSearchFacet has been set to "0"
+				// thus preventing these branches from being displayed as search by options
+				if ($field == 'available_at') {
+					$branchName = substr($facetValue, 5);
+					if (empty($branchList[$branchName]->showInSearchFacet)) {
+						continue;
+					}
+				}
+			
 				if ($isScopedField && strpos($facetValue, '#') !== false) {
 					$facetValue = substr($facetValue, strpos($facetValue, '#') + 1);
 				}


### PR DESCRIPTION
**Description:** 

The request was to add a setting in Primary Configuration > Locations > Searching to hide the branch from the search facets and the advanced search.

This patch implements the first part of that request by adding a 'Show This Branch In Search Facet' checkbox under Searching > Search Facets. This removes the need for additional CSS or JS scripts to hide the ability to search by a specific branch, without affecting the search results themselves (the relevant stock for a branch with a hidden visibility in the search facet will still be found and rendered).

**Test plan:** 

- implement the patch
- login in to Aspen as an admin
- go to Catalog / Grouped Works > 'Grouped Work Facets' in Aspen Administration
- edit 'public'
- add a new facet: Facet: Branch, Display Name: Library, Plural Display Name: Libraries, and save
- run a search
- open the 'Available At' search facet and the 'Libraries' search facet
- take note of the branches listed as search by options
- also take notes of the search results, so that you can compare them to a later search
- navigate to Aspen Discovery Administration > Primary Configuration > Locations(Branches)
- from the list, select one branch that you noted was display in the facet
- click on edit
- on this branch's settings page, navigate to 'Searching' > Search Facets
- notice that 'Show This Branch In Search Facet' is now an option and is enabled (by default)
- uncheck 'Show This Branch In Search Facet' and save your changes
- run an identical search to the earlier one
- open the 'Available At' search facet and the 'Libraries' search facet, and notice that the branch of which you have disable the display in search facet setting does not appear anymore
- also notice that the search results themselves are unaffected (copies found at the branch hidden from the facets still are found and displayed)

Note: it can also be toggled back on, which can be tested following a similar procedure


