### PR TITLE
feat: ILS usage graphs

### DIFF
--- a/code/web/interface/themes/responsive/ILS/dashboard.tpl
+++ b/code/web/interface/themes/responsive/ILS/dashboard.tpl
@@ -60,7 +60,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoPlacedAtLeastOneHold&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -138,7 +138,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithPdfDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -164,7 +164,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoViewedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithPdfViews&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -242,7 +242,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOneSupplementalFile&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithSupplementalFileDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">

--- a/code/web/interface/themes/responsive/ILS/dashboard.tpl
+++ b/code/web/interface/themes/responsive/ILS/dashboard.tpl
@@ -34,7 +34,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Self Registrations" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=selfRegistrations&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Self Registrations" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=selfRegistrations&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -60,7 +60,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=usersWithHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -112,7 +112,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Total Holds" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=totalHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Total Holds" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=totalHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -138,7 +138,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithPdfDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=usersWithPdfDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -164,7 +164,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithPdfViews&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=usersWithPdfViews&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -190,7 +190,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="PDFs Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=pdfsDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="PDFs Downloaded" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=pdfsDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -242,7 +242,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWithSupplementalFileDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=usersWithSupplementalFileDownloads&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -268,7 +268,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Supplemental Files Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=supplementalFilesDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Supplemental Files Downloaded" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=supplementalFilesDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">

--- a/code/web/interface/themes/responsive/ILS/dashboard.tpl
+++ b/code/web/interface/themes/responsive/ILS/dashboard.tpl
@@ -8,7 +8,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-						<h2 class="dashboardCategoryLabel">{translate text="User Logins" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=userLogins&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+							<h2 class="dashboardCategoryLabel">{translate text="User Logins" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=userLogins&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -30,6 +30,7 @@
 						</div>
 					</div>
 				</div>
+
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
@@ -112,7 +113,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="Total Holds" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=totalHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -135,12 +135,10 @@
 					</div>
 				</div>
 
-
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -167,7 +165,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoViewedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -194,7 +191,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="PDFs Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=pdfsDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -221,7 +217,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="PDFs Viewed" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=pdfsViewed&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -248,7 +243,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOneSupplementalFile&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">
@@ -275,7 +269,6 @@
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
 							<h2 class="dashboardCategoryLabel">{translate text="Supplemental Files Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=supplementalFilesDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
-
 						</div>
 					</div>
 					<div class="row">

--- a/code/web/interface/themes/responsive/ILS/dashboard.tpl
+++ b/code/web/interface/themes/responsive/ILS/dashboard.tpl
@@ -2,14 +2,13 @@
 	<div id="main-content" class="col-sm-12">
 		<h1>{translate text="ILS Usage Dashboard" isAdminFacing=true}</h1>
 		{include file="Admin/selectInterfaceForm.tpl"}
-
 		{foreach from=$profiles item=profileName key=profileId}
 			<h1>{translate text="Selected Profile" isAdminFacing=true} - {$profileName}</h1>
 			<div class="row">
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="User Logins" isAdminFacing=true}</h2>
+						<h2 class="dashboardCategoryLabel">{translate text="User Logins" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=userLogins&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -31,11 +30,10 @@
 						</div>
 					</div>
 				</div>
-				
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Self Registrations" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Self Registrations" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=selfRegistrations&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -61,7 +59,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who placed at least one hold" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoPlacedAtLeastOneHold&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -87,7 +85,7 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Records Held" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Records Held" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=recordsHeld&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
 						</div>
 					</div>
 					<div class="row">
@@ -113,7 +111,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Total Holds" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Total Holds" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=totalHolds&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -140,7 +139,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -166,7 +166,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who viewed at least one PDF" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoViewedAtLeastOnePdf&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -192,7 +193,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="PDFs Downloaded" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="PDFs Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=pdfsDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -218,7 +220,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="PDFs Viewed" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="PDFs Viewed" isAdminFacing=true} <a href="/ILS/UsageGraphs?stat=pdfsViewed&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -244,7 +247,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Users who downloaded at least one Supplemental File" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=usersWhoDownloadedAtLeastOneSupplementalFile&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">
@@ -270,7 +274,8 @@
 				<div class="dashboardCategory col-sm-6">
 					<div class="row">
 						<div class="col-sm-10 col-sm-offset-1">
-							<h2 class="dashboardCategoryLabel">{translate text="Supplemental Files Downloaded" isAdminFacing=true}</h2>
+							<h2 class="dashboardCategoryLabel">{translate text="Supplemental Files Downloaded" isAdminFacing=true}<a href="/ILS/UsageGraphs?stat=supplementalFilesDownloaded&instance={$selectedInstance}" title="{translate text="Show User Logins Graph" inAttribute="true"}"><i class="fas fa-chart-line"></i></a></h2>
+
 						</div>
 					</div>
 					<div class="row">

--- a/code/web/interface/themes/responsive/ILS/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/ILS/usage-graph.tpl
@@ -1,0 +1,85 @@
+{strip}
+	<div id="main-content" class="col-sm-12">
+		<h1>{translate text=$graphTitle isAdminFacing=true}</h1>
+		<div class="chart-container" style="position: relative; height:50%; width:100%">
+			<canvas id="chart"></canvas>
+		</div>
+
+		<h2>{translate text="Raw Data" isAdminFacing=true}</h2>
+		<div class="adminTableRegion fixed-height-table">
+			<table class="adminTable table table-responsive table-striped table-bordered table-condensed smallText table-sticky">
+				<thead>
+					<tr>
+						<th>{translate text="Date" isAdminFacing=true}</th>
+						{foreach from=$dataSeries key=seriesLabel item=seriesData}
+							<th>{if !empty($translateDataSeries)}{translate text=$seriesLabel isAdminFacing=true}{else}{$seriesLabel}{/if}</th>
+						{/foreach}
+					</tr>
+				</thead>
+				<tbody>
+					{foreach from=$columnLabels item=label}
+						<tr>
+							<td>{if !empty($translateColumnLabels)}{translate text=$label isAdminFacing=true}{else}{$label}{/if}</td>
+							{foreach from=$dataSeries item=seriesData}
+								<td>{if (empty($seriesData.data.$label))}0{else}{$seriesData.data.$label|number_format}{/if}</td>
+							{/foreach}
+						</tr>
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
+	</div>
+{/strip}
+{literal}
+<script>
+var ctx = document.getElementById('chart');
+var myChart = new Chart(ctx, {
+	type: 'line',
+	data: {
+		labels: [
+			{/literal}
+			{foreach from=$columnLabels item=columnLabel}
+				'{$columnLabel}',
+			{/foreach}
+			{literal}
+		],
+		datasets: [
+			{/literal}
+			{foreach from=$dataSeries key=seriesLabel item=seriesData}
+				{ldelim}
+				label: "{translate text=$seriesLabel isAdminFacing=true}",
+				data: [
+					{foreach from=$seriesData.data item=curValue}
+						{$curValue},
+					{/foreach}
+				],
+				borderWidth: 1,
+				borderColor: '{$seriesData.borderColor}',
+				backgroundColor: '{$seriesData.backgroundColor}',
+				{rdelim},
+			{/foreach}
+			{literal}
+		]
+	},
+	options: {
+		scales: {
+			yAxes: [{
+				ticks: {
+					beginAtZero: true
+				}
+			}],
+			xAxes: [{
+				type: 'category',
+				labels: [
+					{/literal}
+					{foreach from=$columnLabels item=columnLabel}
+						'{$columnLabel}',
+					{/foreach}
+					{literal}
+				]
+			}]
+		}
+	}
+});
+</script>
+{/literal}

--- a/code/web/release_notes/24.08.00.MD
+++ b/code/web/release_notes/24.08.00.MD
@@ -57,6 +57,10 @@ To generate the passkey file, the following command should be run (as root):
 
 // other
 
+// chloe
+### Other Updates
+- Add usage graphs and raw data tables for ILS Integration. These can be accessed through the ILS Integration Dashboard
+
 ## This release includes code contributions from
 - ByWater Solutions
   - Mark Noble (MDN)
@@ -71,6 +75,7 @@ To generate the passkey file, the following command should be run (as root):
   - Pedro Amorim (PA)
   - Alexander Blanchard (AB)
   - Jacob O'Mara (JOM)
+  - Chloe Zermatten (CZ)
 
 - Theke Solutions
   - Lucas Montoya (LM)

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -172,6 +172,47 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$recordILSUsage->selectAdd('year');
 			$recordILSUsage->selectAdd('month');
 			$recordILSUsage->orderBy('year, month');
+
+			if ($stat == 'pdfsDownloaded') {
+				$dataSeries['PDFs Downloaded'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$recordILSUsage->selectAdd('SUM(pdfDownloadCount) as sumPdfsDownloaded');
+			}
+			if ($stat == 'pdfsViewed') {
+				$dataSeries['PDFs Viewed'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$recordILSUsage->selectAdd('SUM(pdfViewCount) as sumPdfsViewed');
+			}
+			if ($stat == 'supplementalFilesDownloaded') {
+				$dataSeries['Supplemental Files Downloaded'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$recordILSUsage->selectAdd('SUM(supplementalFileDownloadCount) as sumSupplementalFilesDownloaded');
+			}
+			if ($stat == 'recordsHeld') {
+				$dataSeries['Records Held'] = [
+					'borderColor' => 'rgba(154, 75, 244, 1)',
+					'backgroundColor' => 'rgba(154, 75, 244, 0.2)',
+					'data' => [],
+				];
+				$recordILSUsage->selectAdd('SUM(recordsHeld) as sumRecordsHeld');
+			}
+			if ($stat == 'totalHolds') {
+				$dataSeries['Total Holds'] = [
+					'borderColor' => 'rgba(54, 162, 235, 1)',
+					'backgroundColor' => 'rgba(54, 162, 235, 0.2)',
+					'data' => [],
+				];
+				$recordILSUsage->selectAdd('SUM(timesUsed) as totalHolds');
+			}
 		}
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -20,6 +20,42 @@ class ILS_UsageGraphs extends Admin_Admin {
 
 		$dataSeries = [];
 		$columnLabels = [];
+				
+		switch ($stat) {
+			case 'userLogins':
+				$title .= ' - User Logins';
+				break;
+			case 'selfRegistrations':
+				$title .= ' - Self Registrations';
+				break;
+			case 'usersWithHolds':
+				$title .= ' - Users Who Placed At Least One Hold';
+				break;
+			case 'recordsHeld':
+				$title .= ' - Records Held';
+				break;
+			case 'totalHolds':
+				$title .= ' - Total Holds';
+				break;
+			case 'usersWithPdfDownloads': 
+				$title .= ' - Users Who Downloaded At Least One PDF';
+				break;
+			case 'usersWithPdfViews':
+				$title .= ' - Users Who Viewed At Least One PDF';
+				break;
+			case 'pdfsDownloaded':
+				$title .= ' - PDFs Downloaded';
+				break;
+			case 'pdfsViewed':
+				$title .= ' - PDFs Viewed';
+				break;
+			case 'usersWithSupplementalFileDownloads':
+				$title .= ' - Users Who Downloaded At Least One Supplemental File';
+				break;
+			case 'supplementalFilesDownloaded':
+				$title .= ' - Supplemental Files Downloaded';
+				break;
+		}
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -156,6 +156,7 @@ class ILS_UsageGraphs extends Admin_Admin {
 				}
 			}
 		}
+
 		// for graphs displaying data retrieved from the ils_record_usage table
 		if (
 			$stat == 'pdfsDownloaded' ||

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -260,4 +260,10 @@ class ILS_UsageGraphs extends Admin_Admin {
 		return 'ils_integration';
 	}
 
+	function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
 }

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -6,4 +6,26 @@ require_once ROOT_DIR . '/sys/ILS/UserILSUsage.php';
 require_once ROOT_DIR . '/sys/ILS/ILSRecordUsage.php';
 
 class ILS_UsageGraphs extends Admin_Admin {
+	function launch() {
+		global $interface;
+		global $enabledModules;
+		global $library;
+		$title = 'ILS Usage Graph';
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+
+		$dataSeries = [];
+		$columnLabels = [];
+		$interface->assign('columnLabels', $columnLabels);
+		$interface->assign('dataSeries', $dataSeries);
+		$interface->assign('translateDataSeries', true);
+		$interface->assign('translateColumnLabels', false);
+
+		$interface->assign('graphTitle', $title);
+		$this->display('usage-graph.tpl', $title);
+	}
 }

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -164,6 +164,14 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$stat == 'recordsHeld' ||
 			$stat == 'totalHolds'
 		) {
+			$recordILSUsage = new ILSRecordUsage();
+			if (!empty($instanceName)) {
+				$recordILSUsage->instance = $instanceName;
+			}
+			$recordILSUsage->selectAdd();
+			$recordILSUsage->selectAdd('year');
+			$recordILSUsage->selectAdd('month');
+			$recordILSUsage->orderBy('year, month');
 		}
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -75,6 +75,54 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$userILSUsage->selectAdd('year');
 			$userILSUsage->selectAdd('month');
 			$userILSUsage->orderBy('year, month');
+			if ($stat == 'userLogins') {
+				$dataSeries['User Logins'] = [
+					'borderColor' => 'rgba(255, 99, 132, 1)',
+					'backgroundColor' => 'rgba(255, 99, 132, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(usageCount) as sumUserLogins');
+			}
+			if ($stat == 'selfRegistrations') {
+				$dataSeries['Self Registration'] = [
+					'borderColor' => 'rgba(255, 159, 64, 1)',
+					'backgroundColor' => 'rgba(255, 159, 64, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(selfRegistrationCount) as sumSelfRegistrations');
+			}
+			if ($stat == 'usersWithPdfDownloads') {
+				$dataSeries['Users Who Downloaded At Least One PDF'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(IF(pdfDownloadCount>0,1,0)) as usersWithPdfDownloads');
+			}
+			if ($stat == 'usersWithPdfViews') {
+				$dataSeries['Users Who Viewed At Least One PDF'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(IF(pdfViewCount>0,1,0)) as usersWithPdfViews');
+			}
+			if ($stat == 'usersWithSupplementalFileDownloads') {
+				$dataSeries['Users Who Downloaded At Least One Supplemental File'] = [
+					'borderColor' => 'rgba(255, 206, 86, 1)',
+					'backgroundColor' => 'rgba(255, 206, 86, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(IF(supplementalFileDownloadCount>0,1,0)) as usersWithSupplementalFileDownloads');
+			}
+			if ($stat == 'usersWithHolds') {
+				$dataSeries['Users Who Placed At Least One Hold'] = [
+					'borderColor' => 'rgba(0, 255, 55, 1)',
+					'backgroundColor' => 'rgba(0, 255, 55, 0.2)',
+					'data' => [],
+				];
+				$userILSUsage->selectAdd('SUM(IF(usageCount>0,1,0)) as usersWithHolds');
+			}
 		}
 		// for graphs displaying data retrieved from the ils_record_usage table
 		if (

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once ROOT_DIR . '/services/Admin/Admin.php';
+require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
+require_once ROOT_DIR . '/sys/ILS/UserILSUsage.php';
+require_once ROOT_DIR . '/sys/ILS/ILSRecordUsage.php';
+
+class ILS_UsageGraphs extends Admin_Admin {
+}

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -66,6 +66,15 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$stat == 'usersWithSupplementalFileDownloads' ||
 			$stat == 'usersWithHolds'
 		) {
+			$userILSUsage = new UserILSUsage();
+			$userILSUsage->groupBy('year, month');
+			if (!empty($instanceName)) {
+				$userILSUsage->instance = $instanceName;
+			}
+			$userILSUsage->selectAdd();
+			$userILSUsage->selectAdd('year');
+			$userILSUsage->selectAdd('month');
+			$userILSUsage->orderBy('year, month');
 		}
 		// for graphs displaying data retrieved from the ils_record_usage table
 		if (

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -204,7 +204,7 @@ class ILS_UsageGraphs extends Admin_Admin {
 					'backgroundColor' => 'rgba(154, 75, 244, 0.2)',
 					'data' => [],
 				];
-				$recordILSUsage->selectAdd('SUM(recordsHeld) as sumRecordsHeld');
+				$recordILSUsage->selectAdd('SUM(IF(timesUsed>0,1,0)) as numRecordsUsed');
 			}
 			if ($stat == 'totalHolds') {
 				$dataSeries['Total Holds'] = [
@@ -232,6 +232,10 @@ class ILS_UsageGraphs extends Admin_Admin {
 					/** @noinspection PhpUndefinedFieldInspection */
 					$dataSeries['Supplemental Files Downloaded']['data'][$curPeriod] = $recordILSUsage->sumSupplementalFilesDownloaded;
 				}
+				if ($stat == 'recordsHeld') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Total Holds']['data'][$curPeriod] = $recordILSUsage->numRecordsUsed;
+				}	
 				if ($stat == 'totalHolds') {
 					/** @noinspection PhpUndefinedFieldInspection */
 					$dataSeries['Total Holds']['data'][$curPeriod] = $recordILSUsage->totalHolds;
@@ -241,7 +245,7 @@ class ILS_UsageGraphs extends Admin_Admin {
 
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);
-		$interface->assign('translateDataSeries', true);
+		$interface->assign('translateDataSeries', true);	
 		$interface->assign('translateColumnLabels', false);
 
 		$interface->assign('graphTitle', $title);

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -123,6 +123,38 @@ class ILS_UsageGraphs extends Admin_Admin {
 				];
 				$userILSUsage->selectAdd('SUM(IF(usageCount>0,1,0)) as usersWithHolds');
 			}
+
+			//Collect results
+			$userILSUsage->find();
+	
+			while ($userILSUsage->fetch()) {
+				$curPeriod = "{$userILSUsage->month}-{$userILSUsage->year}";
+				$columnLabels[] = $curPeriod;
+				if ($stat == 'userLogins' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['User Logins']['data'][$curPeriod] = $userILSUsage->sumUserLogins;
+				}
+				if ($stat == 'selfRegistrations' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Self Registrations']['data'][$curPeriod] = $userILSUsage->sumSelfRegistrations;
+				}
+				if ($stat == 'usersWithPdfDownloads' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Users Who Downloaded At Least One PDF']['data'][$curPeriod] = $userILSUsage->usersWithPdfDownloads;
+				}
+				if ($stat == 'usersWithPdfViews') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Users Who Viewed At Least One PDF']['data'][$curPeriod] = $userILSUsage->usersWithPdfViews;	
+				}
+				if ($stat == 'usersWithHolds') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Users Who Placed At Least One Hold']['data'][$curPeriod] = $userILSUsage->usersWithHolds;	
+				}
+				if ($stat == 'usersWithSupplementalFileDownloads') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Users Who Downloaded At Least One Supplemental File']['data'][$curPeriod] = $userILSUsage->usersWithSupplementalFileDownloads;	
+				}
+			}
 		}
 		// for graphs displaying data retrieved from the ils_record_usage table
 		if (

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -255,4 +255,9 @@ class ILS_UsageGraphs extends Admin_Admin {
 		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
 		return $breadcrumbs;
 	}
+
+	function getActiveAdminSection(): string {
+		return 'ils_integration';
+	}
+
 }

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -246,4 +246,13 @@ class ILS_UsageGraphs extends Admin_Admin {
 		$interface->assign('graphTitle', $title);
 		$this->display('usage-graph.tpl', $title);
 	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#ils_integration', 'ILS Integration');
+		$breadcrumbs[] = new Breadcrumb('/ILS/Dashboard', 'Usage Dashboard');
+		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
+		return $breadcrumbs;
+	}
 }

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -56,6 +56,26 @@ class ILS_UsageGraphs extends Admin_Admin {
 				$title .= ' - Supplemental Files Downloaded';
 				break;
 		}
+		
+		// for graphs displaying data retrieved from the user_ils_usage table
+		if (
+			$stat == 'userLogins' ||
+			$stat == 'selfRegistrations' ||
+			$stat == 'usersWithPdfDownloads' ||
+			$stat == 'usersWithPdfViews' ||
+			$stat == 'usersWithSupplementalFileDownloads' ||
+			$stat == 'usersWithHolds'
+		) {
+		}
+		// for graphs displaying data retrieved from the ils_record_usage table
+		if (
+			$stat == 'pdfsDownloaded' ||
+			$stat == 'pdfsViewed' ||
+			$stat == 'supplementalFilesDownloaded' ||
+			$stat == 'recordsHeld' ||
+			$stat == 'totalHolds'
+		) {
+		}
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -213,7 +213,31 @@ class ILS_UsageGraphs extends Admin_Admin {
 				];
 				$recordILSUsage->selectAdd('SUM(timesUsed) as totalHolds');
 			}
+			
+			//Collect results
+			$recordILSUsage->find();
+			while ($recordILSUsage->fetch()) {
+				$curPeriod = "{$recordILSUsage->month}-{$recordILSUsage->year}";
+				$columnLabels[] = $curPeriod;
+				if ($stat == 'pdfsDownloaded' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['PDFs Downloaded']['data'][$curPeriod] = $recordILSUsage->sumPdfsDownloaded;
+				}
+				if ($stat == 'pdfsViewed' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['PDFs Viewed']['data'][$curPeriod] = $recordILSUsage->sumPdfsViewed;
+				}
+				if ($stat == 'supplementalFilesDownloaded' ) {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Supplemental Files Downloaded']['data'][$curPeriod] = $recordILSUsage->sumSupplementalFilesDownloaded;
+				}
+				if ($stat == 'totalHolds') {
+					/** @noinspection PhpUndefinedFieldInspection */
+					$dataSeries['Total Holds']['data'][$curPeriod] = $recordILSUsage->totalHolds;
+				}	
+			}
 		}
+
 		$interface->assign('columnLabels', $columnLabels);
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);


### PR DESCRIPTION
**Description**

An Aspen admin can now view a usage graph and a raw data table for each of the variables included in the ILS Integration dashboard. This feature used to be limited to the System Reports dashboard, and it is now being extended. 

Note: the implementation is based on the the System Reports existing usage graphs, and intends to mirror it where possible

Features:

- The dashboard now includes links next to the title of each of its sections
- Those links lead to the relevant Usage Graph page
- The Usage Graph page contains both a graph and a raw data table
- While the user is on a given ILS Integration Usage Graph page, the ILS Integration section on the left hand-side options menu remains open (active)

**Test plan:** 

- apply the patch
- log in as an admin
- navigate to Administration Settings > ILS Integration > Dashboard
- click on the link displayed next to a section's header (title) and access the relevant Usage Graph page
- notice that the data displayed matches the summary found on the dashboard