### PR TITLE
Reindexer output path

### DIFF
--- a/code/cron/.idea/artifacts/reindexer.xml
+++ b/code/cron/.idea/artifacts/reindexer.xml
@@ -1,6 +1,6 @@
 <component name="ArtifactManager">
   <artifact type="jar" build-on-make="true" name="reindexer">
-    <output-path>$PROJECT_DIR$/../reindexer/</output-path>
+    <output-path>$PROJECT_DIR$/../reindexer</output-path>
     <root id="archive" name="reindexer.jar">
       <element id="module-output" name="reindexer" />
       <element id="directory" name="META-INF">


### PR DESCRIPTION
On IntelliJ, artifact output directories are pre-set to certain file paths in matching .xml files found in the cron/.iead/artifacts folder. Upon building, the file name which is added to the end of the path starts with a backlash. This leads to a '//' and therefore a malformed path, and the inability to rebuild the .jar file.

This PR removes the trailing backlash on the output path.

Test plan: 
1- in /code/cron/reindexer/src/reindexer/GroupedWorkIndexer.java, change the "Finished processing grouped works (...)' string to a different message
2- on the top menu, select 'Build' > 'Build Artifacts'
3- hover above reindexer in the menu that open, then click Rebuild once the option appears
4- in adb shell, run `java -jar reindexer.jar test.localhostaspen` (making sure you are inside /usr/local/aspen-discovery/code/reindexer)
5- notice that the "Finished processing grouped works (...)" logs despite it having been changed
6- apply the patch
7- repeat steps 2-4, and notice that the message now matches what you have set it to in step 1.
