### PR TITLE
fix: group ils record usage by year and month

### DIFF
--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -75,6 +75,7 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$userILSUsage->selectAdd('year');
 			$userILSUsage->selectAdd('month');
 			$userILSUsage->orderBy('year, month');
+			
 			if ($stat == 'userLogins') {
 				$dataSeries['User Logins'] = [
 					'borderColor' => 'rgba(255, 99, 132, 1)',
@@ -166,6 +167,7 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$stat == 'totalHolds'
 		) {
 			$recordILSUsage = new ILSRecordUsage();
+			$recordILSUsage->groupBy('year, month');
 			if (!empty($instanceName)) {
 				$recordILSUsage->instance = $instanceName;
 			}


### PR DESCRIPTION
Resolves the `SQLSTATE[42000]: Syntax error or access violation: 1140 In aggregated query without GROUP BY, expression https://github.com/Aspen-Discovery/aspen-discovery/issues/1 of SELECT list contains nonaggregated column 'model.ils_record_usage.year'; this is incompatible with sql_mode=only_full_group_by` error