### PR TITLE
Usage data download

### DIFF
--- a/code/web/interface/themes/responsive/Admin/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph.tpl
@@ -29,7 +29,7 @@
 			</table>
 		</div>
 		<div>
-			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="">{translate text='Export To CSV' isAdminFacing=true}</a>
+			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/Admin/AJAX?method=exportUsageData&stat={$stat}&instance={$instance}">{translate text='Export To CSV' isAdminFacing=true}</a>
 			<div id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will cause the page to refresh so the latest data can be retrieved and displayed" isAdminFacing=true}</small></div>
 		</div>
 	</div>

--- a/code/web/interface/themes/responsive/Admin/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph.tpl
@@ -30,7 +30,7 @@
 		</div>
 		<div>
 			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/Admin/AJAX?method=exportUsageData&stat={$stat}&instance={$instance}">{translate text='Export To CSV' isAdminFacing=true}</a>
-			<div id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will cause the page to refresh so the latest data can be retrieved and displayed" isAdminFacing=true}</small></div>
+			<div id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will retrieve the latest data. To see it on screen, refresh this page." isAdminFacing=true}</small></div>
 		</div>
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/Admin/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph.tpl
@@ -30,6 +30,7 @@
 		</div>
 		<div>
 			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="">{translate text='Export To CSV' isAdminFacing=true}</a>
+			<div id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will cause the page to refresh so the latest data can be retrieved and displayed" isAdminFacing=true}</small></div>
 		</div>
 	</div>
 {/strip}

--- a/code/web/interface/themes/responsive/Admin/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph.tpl
@@ -28,6 +28,9 @@
 				</tbody>
 			</table>
 		</div>
+		<div>
+			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="">{translate text='Export To CSV' isAdminFacing=true}</a>
+		</div>
 	</div>
 {/strip}
 {literal}

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -14,6 +14,8 @@
 // alexander
 
 // chloe
+### Other Updates
+- Added an 'Export as CSV' feature for the raw data of the Usage Graphs accessed through the System Reports' usage dashboard. (*CZ*)
 
 // pedro
 

--- a/code/web/services/Admin/AJAX.php
+++ b/code/web/services/Admin/AJAX.php
@@ -1610,4 +1610,11 @@ class Admin_AJAX extends JSON_Action {
 
 		return $result;
 	}
+
+	public function exportUsageData() {
+		require_once ROOT_DIR . '/services/Admin/UsageGraphs.php';
+		$aspenUsageGraph = new Admin_UsageGraphs(); 
+		$aspenUsageGraph->buildCSV();
+		// TODO: trigger page refresh
+	}
 }

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -64,6 +64,19 @@ class Admin_UsageGraphs extends Admin_Admin {
 		$fp = fopen('php://output', 'w');
 		// builds the first row of the table in the CSV - column headers: Dates, and the title of the graph
 		fputcsv($fp, ['Dates', $stat]);
+		// builds each subsequent data row - aka the column value
+		foreach ($dataSeries as $dataSerie) {
+			    $data = $dataSerie['data'];
+				$numRows = count($data);
+				$dates = array_keys($data);
+
+				for($i = 0; $i < $numRows; $i++) {
+					$date = $dates[$i];
+					$value = $data[$date];
+					$row = [$date, $value];
+					fputcsv($fp, $row);
+				}
+		}
 		exit();
 	}
 	private function getAndSetInterfaceDataSeries($stat, $instanceName) {

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -7,7 +7,10 @@ class Admin_UsageGraphs extends Admin_Admin {
 	function launch() {
 		global $interface;
 		$title = 'Aspen Usage Graph';
+		$interface->assign('graphTitle', $title);
+		$this->assignGraphSpecificTitle($stat);
 		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$title = $interface->getVariable('graphTitle');
 		$this->display('usage-graph.tpl', $title);
 	}
 	function getBreadcrumbs(): array {
@@ -52,72 +55,6 @@ class Admin_UsageGraphs extends Admin_Admin {
 		$userUsage->selectAdd('year');
 		$userUsage->selectAdd('month');
 		$userUsage->orderBy('year, month');
-
-		switch ($stat) {
-			case 'generalUsage':
-				$title .= ' - General Usage';
-				break;
-			case 'pageViews':
-				$title .= ' - Pages Viewed';
-				break;
-			case 'authenticatedPageViews':
-				$title .= ' - Authenticated Page Views';
-				break;
-			case 'sessionsStarted':
-				$title = ' - Sessions Started';
-				break;
-			case 'pageViewsByBots':
-				$title .= ' - Pages Viewed By Bots';
-				break;
-			case 'asyncRequests':
-				$title .= ' - Asynchronous Requests';
-				break;
-			case 'coversRequested':
-				$title .= ' - Covers Requested';
-				break;
-			case 'searches':
-				$title .= ' - Searches';
-				break;
-			case 'groupedWorksSearches':
-				$title .= ' - Grouped Work Searches';
-				break;
-			case 'listSearches':
-				$title .= ' - List Searches';
-				break;
-			case 'edsSearches':
-				$title .= ' - EBSCO EDS Searches';
-				break;
-			case 'eventSearches':
-				$title .= ' - Event Searches';
-				break;
-			case 'openArchivesSearches':
-				$title .= ' - Open Archives Searches';
-				break;
-			case 'genealogySearches':
-				$title .= ' - Genealogy Searches';
-				break;
-			case 'exceptionsReport':
-				$title .= ' - Exceptions';
-				break;
-			case 'blockedPages':
-				$title .= ' - Blocked Pages';
-				break;
-			case 'blockedApiRequests':
-				$title .= ' - Blocked API Requests';
-				break;
-			case 'errors':
-				$title .= ' - Errors';
-				break;
-			case 'emailSending':
-				$title .= ' - Email Sending';
-				break;
-			case 'emailsSent':
-				$title .= ' - Emails Sent';
-				break;
-			case 'failedEmails':
-				$title .= ' - Failed Emails';
-				break;
-		}
 
 		//General Usage Stats
 		if ($stat == 'pageViews' || $stat == 'generalUsage') {
@@ -403,6 +340,75 @@ class Admin_UsageGraphs extends Admin_Admin {
 		$interface->assign('translateColumnLabels', false);
 	}
 
+	private function assignGraphSpecificTitle($stat) {
+		global $interface;
+		$title = $interface->getVariable('graphTitle');
+		switch ($stat) {
+			case 'generalUsage':
+				$title .= ' - General Usage';
+				break;
+			case 'pageViews':
+				$title .= ' - Pages Viewed';
+				break;
+			case 'authenticatedPageViews':
+				$title .= ' - Authenticated Page Views';
+				break;
+			case 'sessionsStarted':
+				$title = ' - Sessions Started';
+				break;
+			case 'pageViewsByBots':
+				$title .= ' - Pages Viewed By Bots';
+				break;
+			case 'asyncRequests':
+				$title .= ' - Asynchronous Requests';
+				break;
+			case 'coversRequested':
+				$title .= ' - Covers Requested';
+				break;
+			case 'searches':
+				$title .= ' - Searches';
+				break;
+			case 'groupedWorksSearches':
+				$title .= ' - Grouped Work Searches';
+				break;
+			case 'listSearches':
+				$title .= ' - List Searches';
+				break;
+			case 'edsSearches':
+				$title .= ' - EBSCO EDS Searches';
+				break;
+			case 'eventSearches':
+				$title .= ' - Event Searches';
+				break;
+			case 'openArchivesSearches':
+				$title .= ' - Open Archives Searches';
+				break;
+			case 'genealogySearches':
+				$title .= ' - Genealogy Searches';
+				break;
+			case 'exceptionsReport':
+				$title .= ' - Exceptions';
+				break;
+			case 'blockedPages':
+				$title .= ' - Blocked Pages';
+				break;
+			case 'blockedApiRequests':
+				$title .= ' - Blocked API Requests';
+				break;
+			case 'errors':
+				$title .= ' - Errors';
+				break;
+			case 'emailSending':
+				$title .= ' - Email Sending';
+				break;
+			case 'emailsSent':
+				$title .= ' - Emails Sent';
+				break;
+			case 'failedEmails':
+				$title .= ' - Failed Emails';
+				break;
+		}
+		$interface->assign('graphTitle', $title);
 	}
 
 }

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -6,10 +6,19 @@ require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
 class Admin_UsageGraphs extends Admin_Admin {
 	function launch() {
 		global $interface;
+
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+
 		$title = 'Aspen Usage Graph';
 		$interface->assign('graphTitle', $title);
 		$this->assignGraphSpecificTitle($stat);
 		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$interface->assign('stat', $stat);
 		$title = $interface->getVariable('graphTitle');
 		$this->display('usage-graph.tpl', $title);
 	}

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -41,13 +41,31 @@ class Admin_UsageGraphs extends Admin_Admin {
 			'View System Reports',
 		]);
 	}
+
+	public function buildCSV() {
+		global $interface;
+
 		$stat = $_REQUEST['stat'];
 		if (!empty($_REQUEST['instance'])) {
 			$instanceName = $_REQUEST['instance'];
 		} else {
 			$instanceName = '';
 		}
-	// Helper functions
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$dataSeries = $interface->getVariable('dataSeries');
+
+		$filename = "ApsenUsageData_{$stat}.csv";
+		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+		header("Cache-Control: no-store, no-cache, must-revalidate");
+		header("Cache-Control: post-check=0, pre-check=0", false);
+		header("Pragma: no-cache");
+		header('Content-Type: text/csv; charset=utf-8');
+		header("Content-Disposition: attachment;filename={$filename}");
+		$fp = fopen('php://output', 'w');
+		// builds the first row of the table in the CSV - column headers: Dates, and the title of the graph
+		fputcsv($fp, ['Dates', $stat]);
+		exit();
+	}
 	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
 		global $interface;
 		global $enabledModules;

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -62,17 +62,21 @@ class Admin_UsageGraphs extends Admin_Admin {
 		header('Content-Type: text/csv; charset=utf-8');
 		header("Content-Disposition: attachment;filename={$filename}");
 		$fp = fopen('php://output', 'w');
-		// builds the first row of the table in the CSV - column headers: Dates, and the title of the graph
-		fputcsv($fp, ['Dates', $stat]);
-		// builds each subsequent data row - aka the column value
-		foreach ($dataSeries as $dataSerie) {
-			    $data = $dataSerie['data'];
-				$numRows = count($data);
-				$dates = array_keys($data);
+		$graphTitles = array_keys($dataSeries);
+		$numGraphTitles = count($dataSeries);
 
-				for($i = 0; $i < $numRows; $i++) {
-					$date = $dates[$i];
-					$value = $data[$date];
+		// builds the header for each section of the table in the CSV - column headers: Dates, and the title of the graph
+		for($i = 0; $i < $numGraphTitles; $i++) {
+			$dataSerie = $dataSeries[$graphTitles[$i]];
+			$numRows = count($dataSerie['data']);
+			$dates = array_keys($dataSerie['data']);
+			$header = ['Dates', $graphTitles[$i]];
+			fputcsv($fp, $header);
+
+				// builds each subsequent data row - aka the column value
+				for($j = 0; $j < $numRows; $j++) {
+					$date = $dates[$j];
+					$value = $dataSerie['data'][$date];
 					$row = [$date, $value];
 					fputcsv($fp, $row);
 				}

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -6,15 +6,40 @@ require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
 class Admin_UsageGraphs extends Admin_Admin {
 	function launch() {
 		global $interface;
-		global $enabledModules;
-		global $library;
 		$title = 'Aspen Usage Graph';
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$this->display('usage-graph.tpl', $title);
+	}
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#system_reports', 'System Reports');
+		$breadcrumbs[] = new Breadcrumb('/Admin/UsageDashboard', 'Usage Dashboard');
+		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'system_reports';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
 		$stat = $_REQUEST['stat'];
 		if (!empty($_REQUEST['instance'])) {
 			$instanceName = $_REQUEST['instance'];
 		} else {
 			$instanceName = '';
 		}
+	// Helper functions
+	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
+		global $interface;
+		global $enabledModules;
+		global $library;
 
 		$dataSeries = [];
 		$columnLabels = [];
@@ -276,8 +301,6 @@ class Admin_UsageGraphs extends Admin_Admin {
 			$userUsage->selectAdd('SUM(emailsFailed) as sumFailedEmails');
 		}
 
-
-
 		//Collect results
 		$userUsage->find();
 
@@ -378,28 +401,8 @@ class Admin_UsageGraphs extends Admin_Admin {
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);
 		$interface->assign('translateColumnLabels', false);
-
-		$interface->assign('graphTitle', $title);
-		$this->display('usage-graph.tpl', $title);
 	}
 
-	function getBreadcrumbs(): array {
-		$breadcrumbs = [];
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home#system_reports', 'System Reports');
-		$breadcrumbs[] = new Breadcrumb('/Admin/UsageDashboard', 'Usage Dashboard');
-		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
-		return $breadcrumbs;
 	}
 
-	function getActiveAdminSection(): string {
-		return 'system_reports';
-	}
-
-	function canView(): bool {
-		return UserAccount::userHasPermission([
-			'View Dashboards',
-			'View System Reports',
-		]);
-	}
 }


### PR DESCRIPTION
This patch allows admins to download the content of the usage graphs found within the admin dashboard. If it is approved, the feature can then be added to the usage graphs of Summon and ILS, as well as those of any other dashboards to which usage graphs might be added in the future. 

Clicking the 'Export as CSV' button triggers a fetch of the most recent data for the usage graph and its download as a CSV file. A  warning message to the user indicates that the data in the file may be more recent than the on-screen data (and result in discrepancies), unless they choose to reload the page immediately after the download.

Test plan: 

- once logged in as an Aspen admin, navigate to Aspen Administration > System Reports > Usage Dashboards
- navigate to the various usage graphs within, including section-wide graphs such as 'General Usage'
- notice the added 'Export as CSV' button, and the accompanying warning message
- click 'Export as CSV'
- immediately refresh the page
- check that the file has been downloaded
- check that the values within the CSV match the ones in 'raw data table'
