### PR TITLE
Fix save preferences

### DIFF
--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -34,6 +34,8 @@
 // alexander
 
 // chloe
+### Other updates
+- fixed an issue where attempting to save user preferences would result in an error being displayed on the OPAC and cause the save to fail (*CZ*)
 
 // pedro
 

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -82,8 +82,10 @@ class MyAccount_MyPreferences extends MyAccount {
 						if (!empty($user->updateMessage)) {
 							$user->updateMessage .= '<br/>';
 						}
-						$user->updateMessage .= implode('<br/>', $result2['messages']);
-						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+						if(!empty($result2)){ // $result2 may be null, guard clause required
+							$user->updateMessage .= implode('<br/>', $result2['messages']);
+							$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+						}
 					}
 				}else{
 					$user->updateMessage = translate([

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -2654,7 +2654,11 @@ class User extends DataObject {
 	}
 
 	public function updateHomeLibrary($newHomeLocationCode) {
-		$result = $this->getCatalogDriver()->updateHomeLibrary($this, $newHomeLocationCode);
+		$catalogDriver = $this->getCatalogDriver();
+		if (empty($catalogDriver)) { // getCatalogDriver() may return null, guard clause required
+			return;
+		}
+		$result = $catalogDriver->updateHomeLibrary($this, $newHomeLocationCode);
 		$this->clearCache();
 		return $result;
 	}


### PR DESCRIPTION
During the process of updating user preferences,
$user->getCatalogDriver() may return null, thus the need for a guard clause in $user->updateHomeLibrary. Since this guard clause makes it possible for $user->updatedHomeLibrary to return null as well, an additional guard clause is added to the launch function for 'MyPreferences'.

This sould prevent the 'Member function updateHomeLibrary called on Null' from being displayed on the OPAC upon attempts to save user preferences.

Test plan: 

without the patch:
- login to Aspen
- navigate to Account > Your Preferences
- toggle one or more of the settings
- click 'Update My Preferences'
- notice the error that is then displayed on screen with the message "Member function updateHomeLibrary called on Null. "
- apply the patch, and go through the steps above once more
- notice that this time, upon saving the user preferences, the preferences page is then displayed again with the updated setting(s)