### PR TITLE
Usage data download

### DIFF
--- a/code/web/interface/themes/responsive/Admin/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Admin/usage-graph.tpl
@@ -29,7 +29,7 @@
 			</table>
 		</div>
 		<div>
-			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/Admin/AJAX?method=exportUsageData&stat={$stat}&instance={$instance}">{translate text='Export To CSV' isAdminFacing=true}</a>
+			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/Admin/AJAX?method=exportUsageData&stat={$stat}&instance={if !empty($instance)}{$instance}{/if}">{translate text='Export To CSV' isAdminFacing=true}</a>
 			<div id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will retrieve the latest data. To see it on screen, refresh this page." isAdminFacing=true}</small></div>
 		</div>
 	</div>

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -19,6 +19,7 @@ class Admin_UsageGraphs extends Admin_Admin {
 		$this->assignGraphSpecificTitle($stat);
 		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
 		$interface->assign('stat', $stat);
+		$interface->assign('propName', 'exportToCSV');
 		$title = $interface->getVariable('graphTitle');
 		$this->display('usage-graph.tpl', $title);
 	}


### PR DESCRIPTION
These are the two minor changes as requested by Mark. They aim to resolve warnings that arose in debug mode by ensuring that $propName is defined (which had been omitted), and that a check ensuring that $instance is defined also occurs in Admin/usage-graph.tpl, and not only in the method used by the AJAX request it is passed to.

(Original PR: [https://github.com/PTFS-Europe/aspen-discovery/pull/102](https://github.com/PTFS-Europe/aspen-discovery/pull/102) )