### PR TITLE
Data download for existing usage graphs

### DIFF
--- a/code/web/interface/themes/responsive/ILS/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/ILS/usage-graph.tpl
@@ -28,6 +28,11 @@
 				</tbody>
 			</table>
 		</div>
+		<div>
+			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/ILS/AJAX?method=exportUsageData&stat={$stat}&instance={if !empty($instance)}{$instance}{/if}">{translate text='Export To CSV' isAdminFacing=true}</a>
+			<div id="exportToCSVHelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will retrieve the latest data. To see it on screen, refresh this page." isAdminFacing=true}</small></div>
+		</div>
+	</div>
 	</div>
 {/strip}
 {literal}

--- a/code/web/interface/themes/responsive/Summon/usage-graph.tpl
+++ b/code/web/interface/themes/responsive/Summon/usage-graph.tpl
@@ -28,6 +28,10 @@
 				</tbody>
 			</table>
 		</div>
+		<div>
+			<a id="UsageGraphExport" class="btn btn-sm btn-default" href="/Summon/AJAX?method=exportUsageData&stat={$stat}&instance={if !empty($instance)}{$instance}{/if}">{translate text='Export To CSV' isAdminFacing=true}</a>
+			<div id="exportToCSVHelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Exporting will retrieve the latest data. To see it on screen, refresh this page." isAdminFacing=true}</small></div>
+		</div>
 	</div>
 {/strip}
 {literal}

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -48,6 +48,8 @@
 // alexander
 
 // chloe
+### Other updates
+- CSV usage graphs data download are made available for ILS and Summon usage data (*CZ*)
 
 // pedro
 

--- a/code/web/services/ILS/AJAX.php
+++ b/code/web/services/ILS/AJAX.php
@@ -1,0 +1,9 @@
+<?php
+require_once ROOT_DIR . '/JSON_Action.php';
+class ILS_AJAX extends JSON_Action {
+public function exportUsageData() {
+		require_once ROOT_DIR . '/services/ILS/UsageGraphs.php';
+		$ILSUsageGraph = new ILS_UsageGraphs(); 
+		$ILSUsageGraph->buildCSV();
+	}
+}

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -43,6 +43,47 @@ class ILS_UsageGraphs extends Admin_Admin {
 		]);
 	}
 
+	// note that this will only handle tables with one stat (as is needed for Summon usage data)
+	// to see a version that handle multpile stats, see the Admin/UsageGraphs.php implementation
+	public function buildCSV() {
+		global $interface;
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$dataSeries = $interface->getVariable('dataSeries');
+
+		$filename = "ILSUsageData_{$stat}.csv";
+		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+		header("Cache-Control: no-store, no-cache, must-revalidate");
+		header("Cache-Control: post-check=0, pre-check=0", false);
+		header("Pragma: no-cache");
+		header('Content-Type: text/csv; charset=utf-8');
+		header("Content-Disposition: attachment;filename={$filename}");
+		$fp = fopen('php://output', 'w');
+		
+		// builds the first row of the table in the CSV - column headers: Dates, and the title of the graph
+		fputcsv($fp, ['Dates', $stat]);
+
+		// builds each subsequent data row - aka the column value
+		foreach ($dataSeries as $dataSerie) {
+			$data = $dataSerie['data'];
+			$numRows = count($data);
+			$dates = array_keys($data);
+
+			for($i = 0; $i < $numRows; $i++) {
+				$date = $dates[$i];
+				$value = $data[$date];
+				$row = [$date, $value];
+				fputcsv($fp, $row);
+			}
+		}
+		exit();
+	}
+
 	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
 		global $interface;
 		$dataSeries = [];

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -8,8 +8,6 @@ require_once ROOT_DIR . '/sys/ILS/ILSRecordUsage.php';
 class ILS_UsageGraphs extends Admin_Admin {
 	function launch() {
 		global $interface;
-		global $enabledModules;
-		global $library;
 		$title = 'ILS Usage Graph';
 		$stat = $_REQUEST['stat'];
 		if (!empty($_REQUEST['instance'])) {
@@ -18,11 +16,38 @@ class ILS_UsageGraphs extends Admin_Admin {
 			$instanceName = '';
 		}
 
-		$dataSeries = [];
-		$columnLabels = [];
 		$interface->assign('graphTitle', $title);
 		$this->assignGraphSpecificTitle($stat);
-		
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$interface->assign('stat', $stat);
+		$this->display('usage-graph.tpl', $title);
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#ils_integration', 'ILS Integration');
+		$breadcrumbs[] = new Breadcrumb('/ILS/Dashboard', 'Usage Dashboard');
+		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'ils_integration';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
+
+	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
+		global $interface;
+		$dataSeries = [];
+		$columnLabels = [];
+
 		// for graphs displaying data retrieved from the user_ils_usage table
 		if (
 			$stat == 'userLogins' ||
@@ -215,27 +240,6 @@ class ILS_UsageGraphs extends Admin_Admin {
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);	
 		$interface->assign('translateColumnLabels', false);
-		$this->display('usage-graph.tpl', $title);
-	}
-
-	function getBreadcrumbs(): array {
-		$breadcrumbs = [];
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home#ils_integration', 'ILS Integration');
-		$breadcrumbs[] = new Breadcrumb('/ILS/Dashboard', 'Usage Dashboard');
-		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
-		return $breadcrumbs;
-	}
-
-	function getActiveAdminSection(): string {
-		return 'ils_integration';
-	}
-
-	function canView(): bool {
-		return UserAccount::userHasPermission([
-			'View Dashboards',
-			'View System Reports',
-		]);
 	}
 
 	private function assignGraphSpecificTitle($stat) {

--- a/code/web/services/ILS/UsageGraphs.php
+++ b/code/web/services/ILS/UsageGraphs.php
@@ -20,42 +20,8 @@ class ILS_UsageGraphs extends Admin_Admin {
 
 		$dataSeries = [];
 		$columnLabels = [];
-				
-		switch ($stat) {
-			case 'userLogins':
-				$title .= ' - User Logins';
-				break;
-			case 'selfRegistrations':
-				$title .= ' - Self Registrations';
-				break;
-			case 'usersWithHolds':
-				$title .= ' - Users Who Placed At Least One Hold';
-				break;
-			case 'recordsHeld':
-				$title .= ' - Records Held';
-				break;
-			case 'totalHolds':
-				$title .= ' - Total Holds';
-				break;
-			case 'usersWithPdfDownloads': 
-				$title .= ' - Users Who Downloaded At Least One PDF';
-				break;
-			case 'usersWithPdfViews':
-				$title .= ' - Users Who Viewed At Least One PDF';
-				break;
-			case 'pdfsDownloaded':
-				$title .= ' - PDFs Downloaded';
-				break;
-			case 'pdfsViewed':
-				$title .= ' - PDFs Viewed';
-				break;
-			case 'usersWithSupplementalFileDownloads':
-				$title .= ' - Users Who Downloaded At Least One Supplemental File';
-				break;
-			case 'supplementalFilesDownloaded':
-				$title .= ' - Supplemental Files Downloaded';
-				break;
-		}
+		$interface->assign('graphTitle', $title);
+		$this->assignGraphSpecificTitle($stat);
 		
 		// for graphs displaying data retrieved from the user_ils_usage table
 		if (
@@ -249,8 +215,6 @@ class ILS_UsageGraphs extends Admin_Admin {
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);	
 		$interface->assign('translateColumnLabels', false);
-
-		$interface->assign('graphTitle', $title);
 		$this->display('usage-graph.tpl', $title);
 	}
 
@@ -272,5 +236,46 @@ class ILS_UsageGraphs extends Admin_Admin {
 			'View Dashboards',
 			'View System Reports',
 		]);
+	}
+
+	private function assignGraphSpecificTitle($stat) {
+		global $interface;
+		$title = $interface->getVariable('graphTitle'); 
+		switch ($stat) {
+			case 'userLogins':
+				$title .= ' - User Logins';
+				break;
+			case 'selfRegistrations':
+				$title .= ' - Self Registrations';
+				break;
+			case 'usersWithHolds':
+				$title .= ' - Users Who Placed At Least One Hold';
+				break;
+			case 'recordsHeld':
+				$title .= ' - Records Held';
+				break;
+			case 'totalHolds':
+				$title .= ' - Total Holds';
+				break;
+			case 'usersWithPdfDownloads': 
+				$title .= ' - Users Who Downloaded At Least One PDF';
+				break;
+			case 'usersWithPdfViews':
+				$title .= ' - Users Who Viewed At Least One PDF';
+				break;
+			case 'pdfsDownloaded':
+				$title .= ' - PDFs Downloaded';
+				break;
+			case 'pdfsViewed':
+				$title .= ' - PDFs Viewed';
+				break;
+			case 'usersWithSupplementalFileDownloads':
+				$title .= ' - Users Who Downloaded At Least One Supplemental File';
+				break;
+			case 'supplementalFilesDownloaded':
+				$title .= ' - Supplemental Files Downloaded';
+				break;
+		}
+		$interface->assign('graphTitle', $title);
 	}
 }

--- a/code/web/services/Summon/AJAX.php
+++ b/code/web/services/Summon/AJAX.php
@@ -1,0 +1,9 @@
+<?php
+require_once ROOT_DIR . '/JSON_Action.php';
+class Summon_AJAX extends JSON_Action {
+public function exportUsageData() {
+		require_once ROOT_DIR . '/services/Summon/UsageGraphs.php';
+		$summonUsageGraph = new Summon_UsageGraphs(); 
+		$summonUsageGraph->buildCSV();
+	}
+}

--- a/code/web/services/Summon/UsageGraphs.php
+++ b/code/web/services/Summon/UsageGraphs.php
@@ -20,21 +20,8 @@ class Summon_UsageGraphs extends Admin_Admin {
 		
 		$dataSeries = [];
 		$columnLabels = [];
-
-		switch ($stat) {
-			case 'activeUsers':
-				$title .= ' - Active Users';
-			break;
-			case 'numRecordsViewed':
-				$title .= ' - Number of Records Viewed';
-			break;
-			case 'numRecordsClicked':
-				$title .= ' - Number of Records Clicked';
-			break;
-			case 'totalClicks':
-				$title .= ' - Total Clicks';
-			break;
-		}
+		$interface->assign('graphTitle', $title);
+		$this->assignGraphSpecificTitle($stat);
 
 		// gets data from from user_summon_usage
 		if ($stat == 'activeUsers') {
@@ -129,8 +116,6 @@ class Summon_UsageGraphs extends Admin_Admin {
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);	
 		$interface->assign('translateColumnLabels', false);
-
-		$interface->assign('graphTitle', $title);
 		$this->display('usage-graph.tpl', $title);
 	}
 
@@ -152,5 +137,25 @@ class Summon_UsageGraphs extends Admin_Admin {
 		$breadcrumbs[] = new Breadcrumb('/Summon/SummonDashboard', 'Summon Usage Dashboard');
 		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
 		return $breadcrumbs;
+	}
+
+	private function assignGraphSpecificTitle($stat) {
+		global $interface;
+		$title = $interface->getVariable('graphTitle'); 
+		switch ($stat) {
+			case 'activeUsers':
+				$title .= ' - Active Users';
+			break;
+			case 'numRecordsViewed':
+				$title .= ' - Number of Records Viewed';
+			break;
+			case 'numRecordsClicked':
+				$title .= ' - Number of Records Clicked';
+			break;
+			case 'totalClicks':
+				$title .= ' - Total Clicks';
+			break;
+		}
+		$interface->assign('graphTitle', $title);
 	}
 }

--- a/code/web/services/Summon/UsageGraphs.php
+++ b/code/web/services/Summon/UsageGraphs.php
@@ -6,10 +6,8 @@ require_once ROOT_DIR . '/sys/Summon/UserSummonUsage.php';
 require_once ROOT_DIR . '/sys/Summon/SummonRecordUsage.php';
 
 class Summon_UsageGraphs extends Admin_Admin {
-
 	function launch() {
 		global $interface;
-
 		$title = 'Summon Usage Graph';
 		$stat = $_REQUEST['stat'];
 		if (!empty($_REQUEST['instance'])) {
@@ -17,11 +15,38 @@ class Summon_UsageGraphs extends Admin_Admin {
 		} else {
 			$instanceName = '';
 		}
-		
-		$dataSeries = [];
-		$columnLabels = [];
+
 		$interface->assign('graphTitle', $title);
 		$this->assignGraphSpecificTitle($stat);
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$interface->assign('stat', $stat);
+		$this->display('usage-graph.tpl', $title);
+	}
+
+	function getActiveAdminSection(): string {
+		return 'summon';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#summon', 'Summon');
+		$breadcrumbs[] = new Breadcrumb('/Summon/SummonDashboard', 'Summon Usage Dashboard');
+		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
+		return $breadcrumbs;
+	}
+
+	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
+		global $interface;
+		$dataSeries = [];
+		$columnLabels = [];
 
 		// gets data from from user_summon_usage
 		if ($stat == 'activeUsers') {
@@ -116,27 +141,6 @@ class Summon_UsageGraphs extends Admin_Admin {
 		$interface->assign('dataSeries', $dataSeries);
 		$interface->assign('translateDataSeries', true);	
 		$interface->assign('translateColumnLabels', false);
-		$this->display('usage-graph.tpl', $title);
-	}
-
-	function getActiveAdminSection(): string {
-		return 'summon';
-	}
-
-	function canView(): bool {
-		return UserAccount::userHasPermission([
-			'View Dashboards',
-			'View System Reports',
-		]);
-	}
-
-	function getBreadcrumbs(): array {
-		$breadcrumbs = [];
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
-		$breadcrumbs[] = new Breadcrumb('/Admin/Home#summon', 'Summon');
-		$breadcrumbs[] = new Breadcrumb('/Summon/SummonDashboard', 'Summon Usage Dashboard');
-		$breadcrumbs[] = new Breadcrumb('', 'Usage Graph');
-		return $breadcrumbs;
 	}
 
 	private function assignGraphSpecificTitle($stat) {

--- a/code/web/services/Summon/UsageGraphs.php
+++ b/code/web/services/Summon/UsageGraphs.php
@@ -43,6 +43,47 @@ class Summon_UsageGraphs extends Admin_Admin {
 		return $breadcrumbs;
 	}
 
+	// note that this will only handle tables with one stat (as is needed for Summon usage data)
+	// to see a version that handle multpile stats, see the Admin/UsageGraphs.php implementation
+	public function buildCSV() {
+		global $interface;
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$dataSeries = $interface->getVariable('dataSeries');
+
+		$filename = "SummonUsageData_{$stat}.csv";
+		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+		header("Cache-Control: no-store, no-cache, must-revalidate");
+		header("Cache-Control: post-check=0, pre-check=0", false);
+		header("Pragma: no-cache");
+		header('Content-Type: text/csv; charset=utf-8');
+		header("Content-Disposition: attachment;filename={$filename}");
+		$fp = fopen('php://output', 'w');
+		
+		// builds the first row of the table in the CSV - column headers: Dates, and the title of the graph
+		fputcsv($fp, ['Dates', $stat]);
+
+		// builds each subsequent data row - aka the column value
+		foreach ($dataSeries as $dataSerie) {
+			$data = $dataSerie['data'];
+			$numRows = count($data);
+			$dates = array_keys($data);
+
+			for($i = 0; $i < $numRows; $i++) {
+				$date = $dates[$i];
+				$value = $data[$date];
+				$row = [$date, $value];
+				fputcsv($fp, $row);
+			}
+		}
+		exit();
+	}
+
 	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
 		global $interface;
 		$dataSeries = [];


### PR DESCRIPTION
This patch allows admins to download the content of the usage graphs found within the Summon and ILS usage dashboard. Both of these already had usage graph pages, and the CSV download was the only missing feature.

Clicking the 'Export as CSV' button triggers a fetch of the most recent data for the usage graph from the database as well as its download as a CSV file. A warning message to the user indicates that the data in the file may be more recent than the on-screen data (and result in discrepancies), unless they choose to reload the page immediately after the download.

Test plan:

note: ensure to have some data in the user_ils_usage, user_summon_usage, and ils_record_usage table in aspen db

- once logged in as an Aspen admin, navigate to Aspen Administration > ILS Integration  > Dashboard
- navigate to the various usage graphs within
- notice the added 'Export as CSV' button, and the accompanying warning message
- click 'Export as CSV'
- immediately refresh the page
- check that the file has been downloaded
- check that the values within the CSV match the ones in 'raw data table'

also apply this test plan to Aspen Administration > Summon > Dashboard