### PR TITLE
Fix save preferences

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -102,7 +102,7 @@
 						</div>
 					{/if}
 
-					{if !empty($allowHomeLibraryUpdates)}
+					{if !empty($allowHomeLibraryUpdates)  && !empty($isAssociatedWithILS)}
 						{* Allow editing home library *}
 						<div class="form-group  propertyRow">
 							<label for="homeLocation" class="control-label">{translate text='Home Library' isPublicFacing=true}</label>
@@ -130,7 +130,7 @@
 						</div>
 					{/if}
 
-					{if !empty($allowRememberPickupLocation) && count($pickupLocations) > 1}
+					{if !empty($allowRememberPickupLocation) && count($pickupLocations) > 1 && !empty($isAssociatedWithILS)}
 						{* Allow editing the pickup location *}
 						<div class="form-group propertyRow">
 							<label for="pickupLocation" class="control-label">{translate text='Preferred Pickup Location' isPublicFacing=true}</label>
@@ -154,7 +154,7 @@
 						</div>
 					{/if}
 
-					{if !empty($showAlternateLibraryOptions)}
+					{if !empty($showAlternateLibraryOptions)  && !empty($isAssociatedWithILS)}
 						{if count($locationList) > 2} {* First option is none *}
 							<div class="form-group propertyRow">
 								<label for="myLocation1" class="control-label">{translate text='Alternate Pickup Location 1' isPublicFacing=true}</label>
@@ -165,7 +165,7 @@
 								{/if}
 							</div>
 						{/if}
-						{if count($locationList) > 3} {* First option is none *}
+						{if count($locationList) > 3  && !empty($isAssociatedWithILS)} {* First option is none *}
 							<div class="form-group propertyRow">
 								<label for="myLocation2" class="control-label">{translate text='Alternate Pickup Location 2' isPublicFacing=true}</label>
 								&nbsp;{if $edit == true}{html_options name="myLocation2" id="myLocation2" class="form-control" options=$locationList selected=$profile->myLocation2Id}{else}{$profile->_myLocation2|escape}{/if}
@@ -173,7 +173,7 @@
 						{/if}
 					{/if}
 
-					{if !empty($allowRememberPickupLocation)}
+					{if !empty($allowRememberPickupLocation)  && !empty($isAssociatedWithILS)}
 						<div class="form-group propertyRow">
 							<label for="rememberHoldPickupLocation" class="control-label">{translate text='Bypass pickup location prompt when placing holds' isPublicFacing=true}</label>&nbsp;
 							{if $edit == true}

--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -54,6 +54,8 @@
 - Added an 'Export as CSV' feature for the raw data of the Usage Graphs accessed through the System Reports' usage dashboard. (*CZ*)
 - CSV usage graphs data download are made available for ILS and Summon usage data (*CZ*)
 - Fixed an issue where location-related search facets would disappear by amending the 'Show This Branch In Available At and Owning Location Facets' filter so that it can be applied to any scope. (*CZ*)
+- Fixed an issue where attempting to save user preferences would result in an error being displayed on the OPAC and cause the save to fail (*CZ*)
+- 'Your Preferences' settings only show ILS-related options to users associated with ILS (*CZ*)
 
 // pedro
 

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -38,11 +38,14 @@ class MyAccount_MyPreferences extends MyAccount {
 				$allowHomeLibraryUpdates = ($patronHomeLibrary->allowHomeLibraryUpdates == 1);
 			}
 
+			$isAssociatedWithILS = !empty($user->ils_username) && !empty($user->ils_barcode);
+
 			$interface->assign('canUpdateContactInfo', $canUpdateContactInfo);
 			$interface->assign('showAlternateLibraryOptions', $showAlternateLibraryOptionsInProfile);
 			$interface->assign('allowPickupLocationUpdates', $allowPickupLocationUpdates);
 			$interface->assign('allowRememberPickupLocation', $allowRememberPickupLocation);
 			$interface->assign('allowHomeLibraryUpdates', $allowHomeLibraryUpdates);
+			$interface->assign('isAssociatedWithILS', $isAssociatedWithILS);
 
 			// Determine Pickup Locations
 			$homeLibraryLocations = $patron->getValidHomeLibraryBranches($patron->getAccountProfile()->recordSource);

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -82,8 +82,10 @@ class MyAccount_MyPreferences extends MyAccount {
 						if (!empty($user->updateMessage)) {
 							$user->updateMessage .= '<br/>';
 						}
-						$user->updateMessage .= implode('<br/>', $result2['messages']);
-						$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+						if(!empty($result2)){ // $result2 may be null, guard clause required
+							$user->updateMessage .= implode('<br/>', $result2['messages']);
+							$user->updateMessageIsError = $user->updateMessageIsError && !$result2['success'];
+						}
 					}
 				}else{
 					$user->updateMessage = translate([

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -2654,7 +2654,11 @@ class User extends DataObject {
 	}
 
 	public function updateHomeLibrary($newHomeLocationCode) {
-		$result = $this->getCatalogDriver()->updateHomeLibrary($this, $newHomeLocationCode);
+		$catalogDriver = $this->getCatalogDriver();
+		if (empty($catalogDriver)) { // getCatalogDriver() may return null, guard clause required
+			return;
+		}
+		$result = $catalogDriver->updateHomeLibrary($this, $newHomeLocationCode);
 		$this->clearCache();
 		return $result;
 	}


### PR DESCRIPTION
In continuation of  [https://github.com/PTFS-Europe/aspen-discovery/pull/105](https://github.com/PTFS-Europe/aspen-discovery/pull/105), this also adds a filter to 'Home Library', 'Preferred Pickup Location', 'Alternate Pickup Location 1', 'Alternate Pickup Location 2', and 'Bypass pickup location prompt when placing holds' so that these fields only show for users associated with the ILS integration, as they only are useful in the context of ILS

Note: includes a rebase to 24.09.00 (20.08.2024) 

**Test plan:** 

1- in Aspen, as an admin with no ILS association, go to Account > Your Preferences
2- take note of the fields that display
3- masquerade as a user with ILS association, and repeat 1 and 2
4- compare the fields that showed for the user with no ILS association and those that did for the user with ILS association
ILS-related preference settings should all display for the latter, and only for the latter. 
Also ensure that the user with no ILS association still is able to update all settings that are relevant to them.