### PR TITLE
Usage graphs refactor

### DIFF
--- a/code/web/services/Admin/AJAX.php
+++ b/code/web/services/Admin/AJAX.php
@@ -1614,7 +1614,7 @@ class Admin_AJAX extends JSON_Action {
 	public function exportUsageData() {
 		require_once ROOT_DIR . '/services/Admin/UsageGraphs.php';
 		$aspenUsageGraph = new Admin_UsageGraphs(); 
-		$aspenUsageGraph->buildCSV();
+		$aspenUsageGraph->buildCSV('Admin');
 		// TODO: trigger page refresh
 	}
 }

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -40,4 +40,48 @@ abstract class UsageGraphs_UsageGraphs extends Admin_Admin {
 		]);
 	}
 
+	public function buildCSV(string $section): void {
+		global $interface;
+
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		$dataSeries = $interface->getVariable('dataSeries');
+
+		$filename = "{$section}UsageData_{$stat}.csv";
+		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
+		header("Cache-Control: no-store, no-cache, must-revalidate");
+		header("Cache-Control: post-check=0, pre-check=0", false);
+		header("Pragma: no-cache");
+		header('Content-Type: text/csv; charset=utf-8');
+		header("Content-Disposition: attachment;filename={$filename}");
+		$fp = fopen('php://output', 'w');
+		$graphTitles = array_keys($dataSeries);
+		$numGraphTitles = count($dataSeries);
+
+		// builds the header for each section of the table in the CSV - column headers: Dates, and the title of the graph
+		for($i = 0; $i < $numGraphTitles; $i++) {
+			$dataSerie = $dataSeries[$graphTitles[$i]];
+			$numRows = count($dataSerie['data']);
+			$dates = array_keys($dataSerie['data']);
+			$header = ['Dates', $graphTitles[$i]];
+			fputcsv($fp, $header);
+
+				// builds each subsequent data row - aka the column value
+				if (empty($numRows)) {
+					fputcsv($fp, ['no data found']);
+				}
+				for($j = 0; $j < $numRows; $j++) {
+					$date = $dates[$j];
+					$value = $dataSerie['data'][$date];
+					$row = [$date, $value];
+					fputcsv($fp, $row);
+				}
+		}
+		exit();
+	}
 }

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -7,4 +7,30 @@ abstract class UsageGraphs_UsageGraphs extends Admin_Admin {
 	abstract function getActiveAdminSection(): string;
 	abstract protected function assignGraphSpecificTitle(string $stat): void;
 	abstract protected function getAndSetInterfaceDataSeries(string $stat, string $instanceName): void;
+
+	// methods shared amongst all usagegraph classes
+	protected function launchGraph(string $sectionName): void {
+		global $interface;
+
+		$stat = $_REQUEST['stat'];
+		if (!empty($_REQUEST['instance'])) {
+			$instanceName = $_REQUEST['instance'];
+		} else {
+			$instanceName = '';
+		}
+		$sectionTitle = $sectionName . ' ' . 'Usage Graph';
+
+		$interface->assign('stat', $stat);
+		$interface->assign('section', $sectionName);
+		$interface->assign('graphTitle', $sectionTitle);
+		$interface->assign('showCSVExportButton', true);
+		$interface->assign('propName', 'exportToCSV');
+
+		$this->assignGraphSpecificTitle($stat);
+		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
+		
+		$graphTitle = $interface->getVariable('graphTitle');
+		$this->display('usage-graph.tpl', $graphTitle);
+	}
+
 }

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -1,0 +1,10 @@
+<?php
+require_once ROOT_DIR . '/services/Admin/Admin.php';
+abstract class UsageGraphs_UsageGraphs extends Admin_Admin {
+
+	// method specific enough to be worth writing an implementation for per section
+	abstract function getBreadcrumbs(): array;
+	abstract function getActiveAdminSection(): string;
+	abstract protected function assignGraphSpecificTitle(string $stat): void;
+	abstract protected function getAndSetInterfaceDataSeries(string $stat, string $instanceName): void;
+}

--- a/code/web/services/Admin/AbstractUsageGraphs.php
+++ b/code/web/services/Admin/AbstractUsageGraphs.php
@@ -33,4 +33,11 @@ abstract class UsageGraphs_UsageGraphs extends Admin_Admin {
 		$this->display('usage-graph.tpl', $graphTitle);
 	}
 
+	public function canView(): bool {
+		return UserAccount::userHasPermission([
+			'View Dashboards',
+			'View System Reports',
+		]);
+	}
+
 }

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -21,12 +21,6 @@ class Admin_UsageGraphs extends UsageGraphs_UsageGraphs {
 		return 'system_reports';
 	}
 
-	function canView(): bool {
-		return UserAccount::userHasPermission([
-			'View Dashboards',
-			'View System Reports',
-		]);
-	}
 
 	public function buildCSV() {
 		global $interface;

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -1,28 +1,13 @@
 <?php
 
-require_once ROOT_DIR . '/services/Admin/Admin.php';
+require_once ROOT_DIR . '/services/Admin/AbstractUsageGraphs.php';
 require_once ROOT_DIR . '/sys/SystemLogging/AspenUsage.php';
 
-class Admin_UsageGraphs extends Admin_Admin {
-	function launch() {
-		global $interface;
-
-		$stat = $_REQUEST['stat'];
-		if (!empty($_REQUEST['instance'])) {
-			$instanceName = $_REQUEST['instance'];
-		} else {
-			$instanceName = '';
-		}
-
-		$title = 'Aspen Usage Graph';
-		$interface->assign('graphTitle', $title);
-		$this->assignGraphSpecificTitle($stat);
-		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
-		$interface->assign('stat', $stat);
-		$interface->assign('propName', 'exportToCSV');
-		$title = $interface->getVariable('graphTitle');
-		$this->display('usage-graph.tpl', $title);
+class Admin_UsageGraphs extends UsageGraphs_UsageGraphs {
+	function launch(): void {
+		$this->launchGraph('Admin'); // could refactor to extract the section name ('Admin') from the URL within UsageGraphs_UsageGraphs::launch() itself
 	}
+
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];
 		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -21,48 +21,6 @@ class Admin_UsageGraphs extends UsageGraphs_UsageGraphs {
 		return 'system_reports';
 	}
 
-
-	public function buildCSV() {
-		global $interface;
-
-		$stat = $_REQUEST['stat'];
-		if (!empty($_REQUEST['instance'])) {
-			$instanceName = $_REQUEST['instance'];
-		} else {
-			$instanceName = '';
-		}
-		$this->getAndSetInterfaceDataSeries($stat, $instanceName);
-		$dataSeries = $interface->getVariable('dataSeries');
-
-		$filename = "AspenUsageData_{$stat}.csv";
-		header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " GMT");
-		header("Cache-Control: no-store, no-cache, must-revalidate");
-		header("Cache-Control: post-check=0, pre-check=0", false);
-		header("Pragma: no-cache");
-		header('Content-Type: text/csv; charset=utf-8');
-		header("Content-Disposition: attachment;filename={$filename}");
-		$fp = fopen('php://output', 'w');
-		$graphTitles = array_keys($dataSeries);
-		$numGraphTitles = count($dataSeries);
-
-		// builds the header for each section of the table in the CSV - column headers: Dates, and the title of the graph
-		for($i = 0; $i < $numGraphTitles; $i++) {
-			$dataSerie = $dataSeries[$graphTitles[$i]];
-			$numRows = count($dataSerie['data']);
-			$dates = array_keys($dataSerie['data']);
-			$header = ['Dates', $graphTitles[$i]];
-			fputcsv($fp, $header);
-
-				// builds each subsequent data row - aka the column value
-				for($j = 0; $j < $numRows; $j++) {
-					$date = $dates[$j];
-					$value = $dataSerie['data'][$date];
-					$row = [$date, $value];
-					fputcsv($fp, $row);
-				}
-		}
-		exit();
-	}
 	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
 		global $interface;
 		global $enabledModules;

--- a/code/web/services/Admin/UsageGraphs.php
+++ b/code/web/services/Admin/UsageGraphs.php
@@ -21,7 +21,7 @@ class Admin_UsageGraphs extends UsageGraphs_UsageGraphs {
 		return 'system_reports';
 	}
 
-	private function getAndSetInterfaceDataSeries($stat, $instanceName) {
+	protected function getAndSetInterfaceDataSeries($stat, $instanceName): void {
 		global $interface;
 		global $enabledModules;
 		global $library;
@@ -322,7 +322,7 @@ class Admin_UsageGraphs extends UsageGraphs_UsageGraphs {
 		$interface->assign('translateColumnLabels', false);
 	}
 
-	private function assignGraphSpecificTitle($stat) {
+	protected function assignGraphSpecificTitle(string $stat): void {
 		global $interface;
 		$title = $interface->getVariable('graphTitle');
 		switch ($stat) {


### PR DESCRIPTION
Initial proposal to refactor UsageGraphs classes to extend an abstract UsageGraphs_UsageGraphs class. The aim is to avoid repetition in UsageGraphs classes (eg Admin_UsageGraphs) by moving the methods shared across all of these to UsageGraphs_UsageGraphs .

This refactor only affect Admin_UsageGraphs and is intended as being a bit of a testing ground. If it is approved, it could then be submitted for wider Aspen QA before further work is done towards applying it to other sections. 

Test plan: (functionality should be the exact same before and after applying the patch)
 - ensure to have some data in the aspen_usage table
 - once logged in as an Aspen admin, navigate to Aspen Administration > System Reports > Usage Dashboard
 - hover over the various links (to the right of each header), check that the title matches
 - navigate to the various usage graphs within
 - notice that the data on the graph matches the data on the dashboard
 - notice the added 'Export as CSV' button, and the accompanying warning message
 - click 'Export as CSV'
 - if there is a chance the data has changed, refresh the page
 - check that the file has been downloaded
 - check that the values within the CSV match the ones in 'raw data table'


Note:

There are multiple usage graph classes (OverDrive, RBdigital, CloudLibrary, OpenArchives, Websites, EBSCOhost, EBSCO EDs, Hoopla) that have been made and currently only exist on branches on my personal repo, and can be included in a later. If this refactor is accepted, it could be applied to those before PRs are raised for them, if that is preferable. There is also an [active PR](https://github.com/PTFS-Europe/aspen-discovery/pull/116) which could be updated to include the refactor if it is approved.
