### PR TITLE
24.09.00 summon publication date

### DIFF
--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -8,8 +8,8 @@
 // mark - ByWater
 ### Palace Project Updates
 - Update Palace Project for consortia with multiple settings and overlapping consortia. (Ticket 132146, 134770) (*MDN*)
-  - Update to store active borrow link, preview link, and availability per collection.
-  - Display proper links and availability based on patron home library or the active catalog.
+	- Update to store active borrow link, preview link, and availability per collection.
+	- Display proper links and availability based on patron home library or the active catalog.
 - Remove old non-numeric Palace Project identifiers. (Tickets 130362, 135320) (*MDN*)
 
 ### Sierra Updates
@@ -149,6 +149,8 @@
 </div>
 
 // alexander
+### Summon Updates
+- Added a Publication Date Facet to allow Summon Search Results to be filtered by date of publication. (*AB*)
 
 // chloe
 ### Other Updates
@@ -215,26 +217,26 @@
 
 ## This release includes code contributions from
 - ByWater Solutions
-  - Mark Noble (MDN)
-  - Kirstien Kroeger (KK)
-  - Kodi Lein (KL)
-  - Katherine Perdue (KP)
-  - Kyle M Hall (KMH)
-  - Liz Rea (LR)
+	- Mark Noble (MDN)
+	- Kirstien Kroeger (KK)
+	- Kodi Lein (KL)
+	- Katherine Perdue (KP)
+	- Kyle M Hall (KMH)
+	- Liz Rea (LR)
 
 - Grove For Libraries
-  - Mark Noble (MDN-G)
+	- Mark Noble (MDN-G)
 
 - Howell Carnegie District Library
-  - Jeremy Eden (JE)
+	- Jeremy Eden (JE)
 
 - Nashville Public Library
-  - James Staub (JStaub)
-  
+	- James Staub (JStaub)
+	
 - PTFS-Europe
-  - Pedro Amorim (PA)
-  - Alexander Blanchard (AB)
-  - Chloe Zermatten (CZ)
+	- Pedro Amorim (PA)
+	- Alexander Blanchard (AB)
+	- Chloe Zermatten (CZ)
 
 - Theke Solutions
-  - Lucas Montoya (LM)
+	- Lucas Montoya (LM)

--- a/code/web/services/Summon/Results.php
+++ b/code/web/services/Summon/Results.php
@@ -71,7 +71,9 @@ class Summon_Results extends ResultsAction {
 		$interface->assign('filterList', $appliedFacets);
 		$limitList = $searchObject->getLimitList();
 		$interface->assign('limitList', $limitList);
-		$facetSet = $searchObject->getFacetSet();
+		$facetSetOne = $searchObject->getFacetSet();
+		$facetSetTwo = $searchObject->getRangeFacetSet();
+		$facetSet = array_merge($facetSetOne, $facetSetTwo);
 		$interface->assign('sideFacetSet', $facetSet);
 
 		//Figure out which counts to show.

--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -101,8 +101,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 	protected $rangeFacets = [
 		'PublicationDate,1911:1920,1921:1930,1931:1940,1941:1950,1951:1960,1961:1970,1971:1980,1981:1990,1991:2000,2001:2010,2011:2020,2021:2030',
 	];
-	protected $rangeFilters = [
-	];
+	protected $rangeFilters = array();
 
 	protected $limitList = [];
 	protected $limitFields;
@@ -281,7 +280,6 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 			//allows access to records
 			's.role' =>  'authenticated',			
 		);
-		var_dump($options);
 		return $options;
 	}
 
@@ -302,7 +300,6 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 				$this->rangeFacetFields = $recordData['rangeFacetFields'];
 				$this->rangeFilters = $recordData['query']['rangeFilters'];
 			}
-			var_dump($recordData['query']['queryString']);
 			return $recordData;
 	}
 	
@@ -519,7 +516,6 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 	public function getRangeFacetSet() {
 		$availableRangeFacets = [];
 		$this->rangeFilters = [];
-		
 		if (isset($this->rangeFacetFields)) {
 			foreach ($this->rangeFacetFields as $rangeFacetField) {
 				$facetId = $rangeFacetField['displayName'];
@@ -536,7 +532,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 				foreach ($rangeFacetField['counts'] as $value) {
 					$rangeFacetValue = $value['range'];
 					$rangeValueString = $rangeFacetValue['minValue'] . '-' . $rangeFacetValue['maxValue'];
-					$isApplied = array_key_exists($facetId, $this->rangeFilterList) && in_array($rangeValueString, $this->rangeFilterList[$facetId]);
+					$isApplied = array_key_exists($facetId, $this->filterList) && in_array($rangeValueString, $this->filterList[$facetId]);
 
 					$rangeFacetSettings = [
 						'value' => $rangeFacetValue['minValue'] . '-' . $rangeFacetValue['maxValue'],
@@ -615,9 +611,9 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 			$this->filterList = array_merge($this->limitList, $this->filterList);
 		}
 		foreach ($this->filterList as $key => $value) {
-			// if ($key === 'PublicationDate') {
-			// 	continue;
-			// }
+			if ($key === 'PublicationDate') {
+				continue;
+			}
 			if (is_array($value)) {
 				foreach ($value as $val) {
 					$encodedValue = urlencode($val); 
@@ -632,9 +628,12 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 	}
 
 	public function getSummonRangeFilters() {
-		$this->rangeFilters = [];
+		$this->rangeFilters = array();
 		if (isset($this->filterList)) {
 			foreach ($this->filterList as $key =>$value) {
+				if ($key !== 'PublicationDate') {
+					continue;
+				}
 				if (is_array($value)) {
 					foreach ($value as $val) {
 						$encodedValue = urlencode($val);

--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -99,7 +99,7 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 	];
 
 	protected $rangeFacets = [
-		'PublicationDate,1981:1990,1991:2000',
+		'PublicationDate,1911:1920,1921:1930,1931:1940,1941:1950,1951:1960,1961:1970,1971:1980,1981:1990,1991:2000,2001:2010,2011:2020,2021:2030',
 	];
 
 	protected $limitList = [];


### PR DESCRIPTION
This Pull Request adds a the option to filter Summon Search results by publication date. 
Test Plan:
Prior to applying patch:
1. Set up Summon and carry out a Summon Search. 
2. Note the facet options that are available on the left hand side. 
3. Apply the patch. 
4. Repeat the search. 
5. Note that there is now a facet labelled 'Publication Date.'
6. Test the filter by choosing one of the date filters and ensuring that it applies correctly. 
7. Ensure that the publication date filter does not conflict with other filters by also adding a filter from another facet e.g. 'Content Type' or 'Language.'