### PR TITLE
See all locations enhancement

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -3138,7 +3138,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			$uniqueItemIdsString = implode(',', $uniqueItemIds);
 			$scopeQuery = "SELECT grouped_work_record_items.id as groupedWorkItemId, available, holdable, inLibraryUseOnly, locationOwnedScopes, libraryOwnedScopes, groupedStatusTbl.status as groupedStatus, statusTbl.status as status, 
 								  grouped_work_record_items.groupedWorkRecordId, grouped_work_record_items.groupedWorkVariationId, grouped_work_record_items.itemId, indexed_call_number.callNumber, indexed_shelf_location.shelfLocation, numCopies, isOrderItem, dateAdded, 
-       							  indexed_location_code.locationCode, indexed_sub_location_code.subLocationCode, lastCheckInDate, isVirtual
+       							  indexed_location_code.locationCode, indexed_sub_location_code.subLocationCode, lastCheckInDate, isVirtual, groupedWorkRecordEdition.edition as 'edition'
 								  FROM grouped_work_record_items
 								  LEFT JOIN indexed_status as groupedStatusTbl on groupedStatusId = groupedStatusTbl.id 
 								  LEFT JOIN indexed_status as statusTbl on statusId = statusTbl.id 
@@ -3146,6 +3146,10 @@ class GroupedWorkDriver extends IndexRecordDriver {
 								  LEFT JOIN indexed_shelf_location ON shelfLocationId = indexed_shelf_location.id
 								  LEFT JOIN indexed_location_code on locationCodeId = indexed_location_code.id
 								  LEFT JOIN indexed_sub_location_code on subLocationCodeId = indexed_sub_location_code.id
+								  LEFT JOIN (
+								  	SELECT indexed_edition.edition, grouped_work_records.id, grouped_work_records.editionId from grouped_work_records
+									LEFT JOIN indexed_edition on grouped_work_records.editionId = indexed_edition.id
+								  ) as groupedWorkRecordEdition on groupedWorkRecordId = groupedWorkRecordEdition.id 
 								  where grouped_work_record_items.id IN ($uniqueItemIdsString)";
 			$results = $aspen_db->query($scopeQuery, PDO::FETCH_ASSOC);
 			$scopedItems = $results->fetchAll();

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -17,7 +17,7 @@
 						<tr>
 							{if !empty($showEditionCovers) && $showEditionCovers == 1}
 								<td class="col-tn-2 col-md-2 col-lg-2">
-									<img src="{$recordDriver->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}">
+									<img src="{$item['editionCoverUrl']}" class="img-thumbnail {$coverStyle}">
 								</td>
 							{/if}
 							<td colspan="4">

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -14,19 +14,20 @@
 				</thead>
 				<tbody>
 					{foreach $summaryList item="item"}
-						<tr>
+						<tr class="sectionHeader">
 							{if !empty($showEditionCovers) && $showEditionCovers == 1}
-								<td class="col-tn-2 col-md-2 col-lg-2">
+								<th class="col-tn-2 col-md-2 col-lg-2">
 									<img src="{$item['editionCoverUrl']}" class="img-thumbnail {$coverStyle}">
-								</td>
+								</th>
 							{/if}
-							<td colspan="4">
+							<th>
 								{if !empty($item['edition'])}
 									{$item['edition']}
 								{else}
-									{translate text="Unknown edition" isPublicFacing=true}
+									{translate text="-" isPublicFacing=true}
 								{/if}
-							</td>
+							</th>
+							<th colspan="2"><th>
 						</tr>
 						{foreach from=$item['summary'] item="item"}
 							<tr {if !empty($item.availableCopies)}class="available" {/if}>

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -3,6 +3,9 @@
 	<table class="table table-striped table-condensed itemSummaryTable">
 		<thead>
 		<tr>
+			{if !empty($showEditionCovers) && $showEditionCovers == 1}
+				<th></th>
+			{/if}
 			<th>{translate text="Available Copies" isPublicFacing=true}</th>
 			<th>{translate text="Edition" isPublicFacing=true}</th>
 			<th>{translate text="Location" isPublicFacing=true}</th>
@@ -13,6 +16,11 @@
 		{assign var=numRowsShown value=0}
 		{foreach from=$summary item="item"}
 			<tr {if !empty($item.availableCopies)}class="available" {/if}>
+				{if !empty($showEditionCovers) && $showEditionCovers == 1}
+					<td class="col-tn-2 col-md-2 col-lg-2">
+						<img src="{$recordDriver->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}">
+					</td>
+				{/if}
 				{if $item.onOrderCopies > 0}
 					{if !empty($showOnOrderCounts)}
 						<td>{translate text="%1% on order" 1=$item.onOrderCopies isPublicFacing=true}</td>

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -1,49 +1,98 @@
 {strip}
-<div id="itemSummaryPopup_{$itemSummaryId|escapeCSS}_{$relatedManifestation->format|escapeCSS}" class="itemSummaryPopup">
-	<table class="table table-striped table-condensed itemSummaryTable">
-		<thead>
-		<tr>
-			{if !empty($showEditionCovers) && $showEditionCovers == 1}
-				<th></th>
-			{/if}
-			<th>{translate text="Available Copies" isPublicFacing=true}</th>
-			<th>{translate text="Edition" isPublicFacing=true}</th>
-			<th>{translate text="Location" isPublicFacing=true}</th>
-			<th>{translate text="Call #" isPublicFacing=true}</th>
-		</tr>
-		</thead>
-		<tbody>
-		{assign var=numRowsShown value=0}
-		{foreach from=$summary item="item"}
-			<tr {if !empty($item.availableCopies)}class="available" {/if}>
-				{if !empty($showEditionCovers) && $showEditionCovers == 1}
-					<td class="col-tn-2 col-md-2 col-lg-2">
-						<img src="{$recordDriver->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}">
-					</td>
-				{/if}
-				{if $item.onOrderCopies > 0}
-					{if !empty($showOnOrderCounts)}
-						<td>{translate text="%1% on order" 1=$item.onOrderCopies isPublicFacing=true}</td>
-					{else}
-						<td>{translate text="Copies on order" isPublicFacing=true}</td>
-					{/if}
-				{else}
-					<td>{translate text="%1% of %2%" 1=$item.availableCopies 2=$item.totalCopies isPublicFacing=true}{if !empty($item.availableCopies)} <i class="fa fa-check"></i>{/if}</td>
-				{/if}
-				<td class="notranslate">
-					{if !empty($item.edition)}
-						{$item.edition}
-					{/if}
-				</td>
-				<td class="notranslate">{$item.shelfLocation}</td>
-				<td class="notranslate">
-					{if empty($item.isEContent)}
-						{$item.callNumber}
-					{/if}
-				</td>
-			</tr>
-		{/foreach}
-		</tbody>
-	</table>
-</div>
+	{if !empty($separateItemsByEditionInWhereIsIt) && $separateItemsByEditionInWhereIsIt == 1 && !empty($summaryList)}
+		<div id="itemSummaryPopup_{$itemSummaryId|escapeCSS}_{$relatedManifestation->format|escapeCSS}"
+			class="itemSummaryPopup">
+			<table class="table table-striped table-condensed itemSummaryTable">
+				<thead>
+					<tr>
+						{if !empty($showEditionCovers) && $showEditionCovers == 1}<th></th>{/if}
+						<th>{translate text="Edition" isPublicFacing=true}</th>
+						<th>{translate text="Available Copies" isPublicFacing=true}</th>
+						<th>{translate text="Location" isPublicFacing=true}</th>
+						<th>{translate text="Call #" isPublicFacing=true}</th>
+					</tr>
+				</thead>
+				<tbody>
+					{foreach $summaryList item="item"}
+						<tr>
+							{if !empty($showEditionCovers) && $showEditionCovers == 1}
+								<td class="col-tn-2 col-md-2 col-lg-2">
+									<img src="{$recordDriver->getBookcoverUrl('small')}" class="img-thumbnail {$coverStyle}">
+								</td>
+							{/if}
+							<td colspan="4">
+								{if !empty($item['edition'])}
+									{$item['edition']}
+								{else}
+									{translate text="Unknown edition" isPublicFacing=true}
+								{/if}
+							</td>
+						</tr>
+						{foreach from=$item['summary'] item="item"}
+							<tr {if !empty($item.availableCopies)}class="available" {/if}>
+								{if !empty($showEditionCovers) && $showEditionCovers == 1}
+									<td></td>
+								{/if}
+								<td></td>
+								{if $item.onOrderCopies > 0}
+									{if !empty($showOnOrderCounts)}
+										<td>{translate text="%1% on order" 1=$item.onOrderCopies isPublicFacing=true}</td>
+									{else}
+										<td>{translate text="Copies on order" isPublicFacing=true}</td>
+									{/if}
+								{else}
+									<td>{translate text="%1% of %2%" 1=$item.availableCopies 2=$item.totalCopies isPublicFacing=true}{if !empty($item.availableCopies)}
+										<i class="fa fa-check"></i>{/if}
+									</td>
+								{/if}
+								<td class="notranslate">{$item.shelfLocation}</td>
+								<td class="notranslate">
+									{if empty($item.isEContent)}
+										{$item.callNumber}
+									{/if}
+								</td>
+							</tr>
+						{/foreach}
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
+	{else}
+		<div id="itemSummaryPopup_{$itemSummaryId|escapeCSS}_{$relatedManifestation->format|escapeCSS}"
+			class="itemSummaryPopup">
+			<table class="table table-striped table-condensed itemSummaryTable">
+				<thead>
+					<tr>
+						<th>{translate text="Available Copies" isPublicFacing=true}</th>
+						<th>{translate text="Location" isPublicFacing=true}</th>
+						<th>{translate text="Call #" isPublicFacing=true}</th>
+					</tr>
+				</thead>
+				<tbody>
+					{assign var=numRowsShown value=0}
+					{foreach from=$summary item="item"}
+						<tr {if !empty($item.availableCopies)}class="available" {/if}>
+							{if $item.onOrderCopies > 0}
+								{if !empty($showOnOrderCounts)}
+									<td>{translate text="%1% on order" 1=$item.onOrderCopies isPublicFacing=true}</td>
+								{else}
+									<td>{translate text="Copies on order" isPublicFacing=true}</td>
+								{/if}
+							{else}
+								<td>{translate text="%1% of %2%" 1=$item.availableCopies 2=$item.totalCopies isPublicFacing=true}{if !empty($item.availableCopies)}
+									<i class="fa fa-check"></i>{/if}
+								</td>
+							{/if}
+							<td class="notranslate">{$item.shelfLocation}</td>
+							<td class="notranslate">
+								{if empty($item.isEContent)}
+									{$item.callNumber}
+								{/if}
+							</td>
+						</tr>
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
+	{/if}
 {/strip}

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -4,6 +4,7 @@
 		<thead>
 		<tr>
 			<th>{translate text="Available Copies" isPublicFacing=true}</th>
+			<th>{translate text="Edition" isPublicFacing=true}</th>
 			<th>{translate text="Location" isPublicFacing=true}</th>
 			<th>{translate text="Call #" isPublicFacing=true}</th>
 		</tr>
@@ -21,6 +22,13 @@
 				{else}
 					<td>{translate text="%1% of %2%" 1=$item.availableCopies 2=$item.totalCopies isPublicFacing=true}{if !empty($item.availableCopies)} <i class="fa fa-check"></i>{/if}</td>
 				{/if}
+				<td class="notranslate">
+					{if !empty($item.edition)}
+						{$item.edition}
+					{else}
+						{translate text='unknown' isPublicFacing=true}
+					{/if}
+				</td>
 				<td class="notranslate">{$item.shelfLocation}</td>
 				<td class="notranslate">
 					{if empty($item.isEContent)}

--- a/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copyDetails.tpl
@@ -33,8 +33,6 @@
 				<td class="notranslate">
 					{if !empty($item.edition)}
 						{$item.edition}
-					{else}
-						{translate text='unknown' isPublicFacing=true}
 					{/if}
 				</td>
 				<td class="notranslate">{$item.shelfLocation}</td>

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -10382,6 +10382,9 @@ a.browse-thumbnail.active {
 .related_record_status.availableOther {
   color: #c62828;
 }
+.itemSummaryTable tr.sectionHeader {
+  border-top: solid #505050 4px;
+}
 .itemSummaryTable tr.available {
   font-weight: bold;
 }

--- a/code/web/interface/themes/responsive/css/results-list.less
+++ b/code/web/interface/themes/responsive/css/results-list.less
@@ -232,6 +232,9 @@
 .related_record_status.availableOther{
   color: #c62828;
 }
+.itemSummaryTable tr.sectionHeader {
+  border-top: solid #505050 4px;
+}
 .itemSummaryTable tr.available{
   font-weight: bold;
 }

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -107,8 +107,8 @@
 - When the cron runs for the first time after a library enables cookieStorageConsent, users who have not opted in to localAnalyticsTracking will have their data cleared from the user_usage statistics tables. (*AB*)
 
 // chloe - PTFS-E 
-## Aspen Usage Data
-- added usage graphs and raw data tables for the Axis360, Aspen API, and SideLoads usage dashboards, all of which include a CSV download feature. (*CZ*)
+- Added a 'Show Editions in the Where is it popup' setting to Aspen Administration > Catalog/Grouped Works > Grouped Work Display > ... > Searching> Search Results, which groups copies in the 'Where is it?' popup by edition, displaying each edition's name and book cover thumbnail in the popup (visibility toggled on/off by 'Show Covers for Editions') (*CZ*)## Aspen Usage Data
+- Added usage graphs and raw data tables for the Axis360, Aspen API, and SideLoads usage dashboards, all of which include a CSV download feature. (*CZ*)
 // pedro - PTFS-E
 
 // lucas - Theke

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -1542,6 +1542,7 @@ class GroupedWork_AJAX extends JSON_Action {
 		$id = $_REQUEST['id'];
 		$recordDriver = new GroupedWorkDriver($id);
 		$interface->assign('recordDriver', $recordDriver);
+		$separateItemsByEditionInWhereIsIt = $interface->getVariable('separateItemsByEditionInWhereIsIt');
 
 		$recordId = $_REQUEST['recordId'];
 		$selectedFormat = urldecode($_REQUEST['format']);
@@ -1555,6 +1556,7 @@ class GroupedWork_AJAX extends JSON_Action {
 		$interface->assign('itemSummaryId', $id);
 		$interface->assign('relatedManifestation', $relatedManifestation);
 
+		$summaryList = [];
 		if ($recordId != $id) {
 			$record = $recordDriver->getRelatedRecord($recordId);
 			$summary = null;
@@ -1570,6 +1572,7 @@ class GroupedWork_AJAX extends JSON_Action {
 						break;
 					}
 				}
+				$interface->assign('summary', $summary);
 			} else {
 				foreach ($relatedManifestation->getVariations() as $variation) {
 					if ($recordId == $id . '_' . $variation->label) {
@@ -1577,12 +1580,24 @@ class GroupedWork_AJAX extends JSON_Action {
 						break;
 					}
 				}
+				$interface->assign('summary', $summary);
 			}
 		} else {
-			$summary = $relatedManifestation->getItemSummary();
+			if(!empty($separateItemsByEditionInWhereIsIt) && $separateItemsByEditionInWhereIsIt == 1) {
+				foreach ($recordDriver->getRelatedRecords() as $relatedRecord) {
+					$item = [];
+					$item['summary'] = $relatedRecord->getItemSummary();
+					$item['editionCoverUrl'] = $relatedRecord->getBookcoverUrl('small');
+					$item['edition'] = $relatedRecord->edition;
+					array_push($summaryList, $item);
+				}
+				$interface->assign('summaryList', $summaryList);
+			} else {
+				$summary = $relatedManifestation->getItemSummary();
+				$interface->assign('summary', $summary);
+			}
 		}
-		$interface->assign('summary', $summary);
-
+		
 		$modalBody = $interface->fetch('GroupedWork/copyDetails.tpl');
 		return [
 			'title' => translate([

--- a/code/web/sys/DBMaintenance/version_updates/24.10.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.10.00.php
@@ -167,6 +167,14 @@ Thank you for your purchase suggestion!', 0, 1, -1)",
 		],
 
 		//chloe - PTFS-Europe
+		'add_separate_items_by_edition_in_where_is_it' => [
+			'title' => 'Add Separate Items By Edition in Where is it',
+			'description' => 'Add the separateItemsByEditionInWhereIsIt column to grouped_work_display_settings in order for the "Show Editions in the Where is it popup" setting to be added',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE grouped_work_display_settings ADD COLUMN separateItemsByEditionInWhereIsIt TINYINT(1) DEFAULT 0',
+			],
+		], // add_separate_items_by_edition_in_where_is_it
 
 		//pedro - PTFS-Europe
 

--- a/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
+++ b/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
@@ -31,6 +31,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 	public $alwaysFlagNewTitles;
 	public $showRelatedRecordLabels;
 	public $showEditionCovers;
+	public $separateItemsByEditionInWhereIsIt;
 
 	//Contents of search
 	public $includeOutOfSystemExternalLinks;
@@ -266,6 +267,14 @@ class GroupedWorkDisplaySetting extends DataObject {
 								'default' => true,
 								'hideInLists' => true,
 							],
+							'separateItemsByEditionInWhereIsIt' => [
+								'property' => 'separateItemsByEditionInWhereIsIt',
+								'type' => 'checkbox',
+								'label' => 'Show Editions in the Where is it popup',
+								'description' => 'Divide the Where is it popup table into edition sections so that edition information can be displayed. If Show Covers for Editions is toggled on, also include edition covers as thumbnails.',
+								'default' => false,
+								'hideInLists' => true
+							]
 						],
 					],
 					'searchFacetsSection' => [
@@ -921,6 +930,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 		$defaultDisplaySettings->alwaysFlagNewTitles = false;
 		$defaultDisplaySettings->showRelatedRecordLabels = true;
 		$defaultDisplaySettings->showEditionCovers = true;
+		$defaultDisplaySettings->separateItemsByEditionInWhereIsIt = false;
 		$defaultDisplaySettings->availabilityToggleLabelSuperScope = 'Entire Collection';
 		$defaultDisplaySettings->availabilityToggleLabelLocal = '';
 		$defaultDisplaySettings->availabilityToggleLabelAvailable = 'Available Now';

--- a/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
+++ b/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
@@ -271,7 +271,7 @@ class GroupedWorkDisplaySetting extends DataObject {
 								'property' => 'separateItemsByEditionInWhereIsIt',
 								'type' => 'checkbox',
 								'label' => 'Show Editions in the Where is it popup',
-								'description' => 'Divide the Where is it popup table into edition sections so that edition information can be displayed. If Show Covers for Editions is toggled on, also include edition covers as thumbnails.',
+								'description' => 'Turn on to divide the Where is it popup table into edition sections so that edition information can be displayed. If Show Covers for Editions is toggled on, also include edition covers as thumbnails.',
 								'default' => false,
 								'hideInLists' => true
 							]

--- a/code/web/sys/Grouping/Item.php
+++ b/code/web/sys/Grouping/Item.php
@@ -25,6 +25,8 @@ class Grouping_Item {
 	public $locallyOwned;
 	/** @var bool */
 	public $holdable;
+	/** @var string */
+	public $edition;
 	/**
 	 * @var bool
 	 */
@@ -81,6 +83,7 @@ class Grouping_Item {
 			$this->isOrderItem = (bool)$itemDetails['isOrderItem'];
 			$this->isEContent = $itemDetails['isEcontent'];
 			$this->eContentSource = $itemDetails['eContentSource'];
+			$this->edition = $itemDetails['edition'];
 			if ($this->isEContent && !empty($itemDetails['localUrl'])) {
 				$this->_relatedUrls[] = [
 					'source' => $itemDetails['eContentSource'],
@@ -294,6 +297,7 @@ class Grouping_Item {
 			'subLocation' => $this->subLocation,
 			'itemId' => $this->itemId,
 			'variationId' => $this->variationId,
+			'edition' => $this->edition,
 			'actions' => $this->getActions(),
 		];
 		return $itemSummaryInfo;

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -627,6 +627,7 @@ class UInterface extends Smarty {
 		$this->assign('alwaysShowSearchResultsMainDetails', $groupedWorkDisplaySettings->alwaysShowSearchResultsMainDetails);
 		$this->assign('showRelatedRecordLabels', $groupedWorkDisplaySettings->showRelatedRecordLabels);
 		$this->assign('showEditionCovers', $groupedWorkDisplaySettings->showEditionCovers);
+		$this->assign('separateItemsByEditionInWhereIsIt', $groupedWorkDisplaySettings->separateItemsByEditionInWhereIsIt);
 		$this->assign('showExpirationWarnings', $library->showExpirationWarnings);
 		$this->assign('expiredMessage', $library->expiredMessage);
 		$this->assign('expirationNearMessage', $library->expirationNearMessage);
@@ -682,6 +683,7 @@ class UInterface extends Smarty {
 			$this->assign('showStandardReviews', $groupedWorkDisplaySettings->showStandardReviews);
 			$this->assign('showRelatedRecordLabels', $groupedWorkDisplaySettings->showRelatedRecordLabels);
 			$this->assign('showEditionCovers', $groupedWorkDisplaySettings->showEditionCovers);
+			$this->assign('separateItemsByEditionInWhereIsIt', $groupedWorkDisplaySettings->separateItemsByEditionInWhereIsIt);
 		} else { // library only
 			$groupedWorkDisplaySettings = $library->getGroupedWorkDisplaySettings();
 			$this->assign('showFavorites', $library->showFavorites);
@@ -697,6 +699,7 @@ class UInterface extends Smarty {
 			$this->assign('showStandardReviews', $groupedWorkDisplaySettings->showStandardReviews);
 			$this->assign('showRelatedRecordLabels', $groupedWorkDisplaySettings->showRelatedRecordLabels);
 			$this->assign('showEditionCovers', $groupedWorkDisplaySettings->showEditionCovers);
+			$this->assign('separateItemsByEditionInWhereIsIt', $groupedWorkDisplaySettings->separateItemsByEditionInWhereIsIt);
 		}
 		if ($showStaffView == 2) {
 			$showStaffView = UserAccount::isStaff();


### PR DESCRIPTION
Update on [the patch enhancing the 'Where is it?](https://github.com/PTFS-Europe/aspen-discovery/pull/118)' modal by adding edition information as well as book cover thumbnails, as requested in [ticket](https://app.plane.so/ptfs-europe/projects/b24083da-a488-4563-a393-9101dacefd66/issues/)

**Test plan**

Checking that the setting displays properly
- navigate to  Aspen Administration > Catalog/Grouped Works > Grouped Work Display > _setting in use_ > Searching> Search Results
- notice that a new 'Show Editions in the Where is it popup' setting is displayed
- hover over the interrogation mark, and notice its description explain its behaviour (changes the structure of the table show on the 'Where is it' modal by breaking it down into 'edition' section, which is what allows edition info to be shown)

Checking functionality:

The following steps should be tried out for the configurations below (in 'Grouped Work Display', as above):
steps:
- run a search
- open and close the 'Where is it?' links on various search results
- also open 'Show Edition(s) for various search results, and open the 'Where is it?' links found there.

to ascertain that default behaviour has not been affected (should be identical to testing without the patch):
- 'Show Editions in the Where is it popup': off
- 'Show Covers for Editions': off
- 'Copy Information to show':  'Show first 3 available copied & Where Is It link always' or 'Show Where is it link only'
-> The 'Where is it' table should display copies per location irrespective of edition

to test the feature including edition cover thumbnails:
- 'Show Editions in the Where is it popup': on
- 'Show Covers for Editions': on
- 'Copy Information to show':  'Show first 3 available copied & Where Is It link always' or 'Show Where is it link only'
-> The 'Where is it' table should include edition sections with headers showing edition info and cover

to test the feature without edition cover thumbnails:
- 'Show Editions in the Where is it popup': on
- 'Show Covers for Editions': off
- 'Copy Information to show':  'Show first 3 available copied & Where Is It link always' or 'Show Where is it link only'
-> The 'Where is it' table should include edition sections with headers showing edition info


Note: when opening  'Show Edition(s)' on various search results, and testing the 'Where is it?' links within, check that they are made of only one section, match the selected edition, and contain all relevant copy summary information.