### PR TITLE
fix: unique username field id

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
@@ -25,7 +25,7 @@
 		<div id="loginUsernameRow" class="form-group">
 			<label for="username" class="control-label col-xs-12 col-sm-4">{translate text=$usernameLabel isPublicFacing=true}</label>
 			<div class="col-xs-12 col-sm-8">
-				<input type="text" name="username" id="username" value="{if !empty($username)}{$username|escape}{/if}" size="28" class="form-control" maxlength="60">
+				<input type="text" name="username" id="ajaxLoginUsername" value="{if !empty($username)}{$username|escape}{/if}" size="28" class="form-control" maxlength="60">
 			</div>
 		</div>
 		<div id="loginPasswordRow" class="form-group">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5994,6 +5994,9 @@ AspenDiscovery.Account = (function () {
 			var username = $("#username").val(),
 				password = $("#password").val(),
 				loginErrorElem = $('#loginError');
+			if(!username) {
+				username = $('#ajaxLoginUsername').val();
+			}
 			if (!username || !password) {
 				loginErrorElem
 					.text($("#missingLoginPrompt").text())
@@ -6021,6 +6024,9 @@ AspenDiscovery.Account = (function () {
 		processAjaxLogin: function (ajaxCallback) {
 			if (this.preProcessLogin()) {
 				var username = $("#username").val();
+				if(!username) {
+					username = $('#ajaxLoginUsername').val();
+				}
 				var password = $("#password").val();
 				var rememberMe = $("#rememberMe").prop('checked');
 				var loginErrorElem = $('#loginError');

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -497,6 +497,9 @@ AspenDiscovery.Account = (function () {
 			var username = $("#username").val(),
 				password = $("#password").val(),
 				loginErrorElem = $('#loginError');
+			if(!username) {
+				username = $('#ajaxLoginUsername').val();
+			}
 			if (!username || !password) {
 				loginErrorElem
 					.text($("#missingLoginPrompt").text())
@@ -524,6 +527,9 @@ AspenDiscovery.Account = (function () {
 		processAjaxLogin: function (ajaxCallback) {
 			if (this.preProcessLogin()) {
 				var username = $("#username").val();
+				if(!username) {
+					username = $('#ajaxLoginUsername').val();
+				}
 				var password = $("#password").val();
 				var rememberMe = $("#rememberMe").prop('checked');
 				var loginErrorElem = $('#loginError');


### PR DESCRIPTION
A user might attempt to sign in while viewing the PIN email reset page (MyAccount/EmailResetPin). Without this patch, any attempt at submitting login info through the login form popup while on said page will fail.

This is because there is both a username field in the PIN email reset form and in the login form, and both share the same id. Since the log in form is referred to as the 'ajax-login' template, this patch changes the id of its username field to 'ajaxLoginUsername', so that it is unique in this scenario.

To replicate:
- go to /MyAccount/EmailResetPin
- select 'Sign In'
- fill in the form with valid credentials
- notice the 'Please enter both Library Barcode and PIN / Password.' error message.

Test plan:

- apply this patch
- repeat the steps above
- notice that, instead of an error, you are logged in as normal.