### PR TITLE
24.09.01 remove hide branches in search facets

### DIFF
--- a/code/web/release_notes/24.09.00.MD
+++ b/code/web/release_notes/24.09.00.MD
@@ -186,7 +186,7 @@
 - Remove 'required' flag for Order Record Status to treat as Under Consideration in Indexing Profiles (*KL*)
 - Remove false error message "Payment amount did not match..." for NCR payments (*KL*)
 - Account for patron types being '0' when doing boolean check to get the patron type object (*KL*)
-- Fixed an issue where location-related search facets would disappear by amending the 'Show This Branch In Available At and Owning Location Facets' filter so that it can be applied to any scope. (*CZ*)
+- Disabled the 'Show This Branch In Available At and Owning Location Facets' filter and setting as it is interacting poorly with facet labels. (*CZ*) -->
 - Fixed an issue where attempting to save user preferences would result in an error being displayed on the OPAC and cause the save to fail (*CZ*)
 - 'Your Preferences' settings only show ILS-related options to users associated with ILS (*CZ*)
 - In the 'Administration Options' sidebar, automatically place the cursor at the start of the search bar when the 'Search' option is clicked (*CZ*)

--- a/code/web/sys/DBMaintenance/version_updates/24.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.09.00.php
@@ -177,7 +177,13 @@ function getUpdates24_09_00(): array {
 			'continueOnError' => false,
 			'sql' => ["ALTER TABLE user_list_entry MODIFY COLUMN sourceId VARCHAR(255)"]
 
-		], //
+		], // sourceId_allow_255_char
+		'remove_showInSearchFacet' => [
+			'title' => 'Remove showInSearchFacet',
+			'description' => 'Remove the showInSearchFacet column from the Location table as part of the removal of the feature to hide branches from search facets',
+			'continueOnError' => false,
+			'sql' => ["ALTER TABLE location DROP COLUMN showInSearchFacet"]
+		], // remove_showInSearchFacet
 
 		//pedro - PTFS-Europe
 

--- a/code/web/sys/LibraryLocation/Location.php
+++ b/code/web/sys/LibraryLocation/Location.php
@@ -45,7 +45,6 @@ class Location extends DataObject {
 	public $createSearchInterface;
 	public $showInSelectInterface;
 	public $showOnDonationsPage;
-	public $showInSearchFacet;
 	public $enableAppAccess;
 	public $appReleaseChannel;
 	public $theme;
@@ -923,15 +922,6 @@ class Location extends DataObject {
 								'hideInLists' => true,
 								'default' => true,
 								'forcesReindex' => true,
-							],
-							[
-								'property' => 'showInSearchFacet',
-								'type' => 'checkbox',
-								'label' => 'Show This Branch In Available At and Owning Location Facets',
-								'description' => 'Whether or not the library should appear as a location that can be selected to filter search results by in the Available At and Owning Location facets.',
-								'hideInLists' => true,
-								'default' => true,
-								'forcesReindex' => false,
 							],
 							[
 								'property' => 'additionalLocationsToShowAvailabilityFor',

--- a/code/web/sys/SearchObject/GroupedWorkSearcher2.php
+++ b/code/web/sys/SearchObject/GroupedWorkSearcher2.php
@@ -786,33 +786,10 @@ class SearchObject_GroupedWorkSearcher2 extends SearchObject_AbstractGroupedWork
 			// Loop through values:
 			$isScopedField = $this->isScopedField($field);
 
-			// Get a list of branches so we can access their 'showInSearchFacet' value
-			// Also rename the keys to the branches' names so they can easily be accessed later
-			$branchList = null;
-			if ($field == 'available_at' || $field == 'owning_location') {
-				$mainBranch = new Location();
-				$branchList = $mainBranch->getLocationListAsObjects(false);
-				// may need to be optimised / unsure how heavy this is
-				foreach ($branchList as $key=>$value) {
-					$branchList[$value->displayName] = $value;
-					unset($branchList[$key]);
-				}
-			}
 			foreach ($data as $facet) {
 				// Initialize the array of data about the current facet:
 				$currentSettings = [];
 				$facetValue = $facet[0];
-				
-				// if populating the array of facet options for 'available at'
-				// then filter out any branch (location) for which showInSearchFacet has been set to "0"
-				// thus preventing these branches from being displayed as search by options
-				if ($field == 'available_at' || $field == 'owning_location') {
-					$scopeCodeLength = strlen($solrScope); // get the length of the scope
-					$branchName = substr($facetValue,  $scopeCodeLength + 1); // extract the branch's name by removing the scope code and hash that precede it
-					if (empty($branchList[$branchName]->showInSearchFacet)) {
-						continue;
-					}
-				}
 			
 				if ($isScopedField && strpos($facetValue, '#') !== false) {
 					$facetValue = substr($facetValue, strpos($facetValue, '#') + 1);


### PR DESCRIPTION
This removes the 'Show This Branch in Available At and Owning Locations
Facets' setting and filter in order to resolve the bug created by the
introduction of this feature.

Bug: branches disappearing from location-related search facets

Cause: the filter ultimately (and incorrectly) compares $displayName to
$facetLabel (as extracted from $facetValue) when attempting to access a
location's 'showInSearchFacet' property and check its value.
If those don't match, no branch is found, the check fails, and the
branch is not added to the facet

Test plan:

to replicate the bug:
- run a search and take notes of the branches appearing in the Available
At search facet
- for one of these branches, set  the  'Library System Facet Label' to a
value that does not match that Library System's display name
- run a search again
- notice the branch has disappeared from the search facet

apply the patch, then go through the test plan again: the branch should
be display in the serach facet correctly, no matter what its label is
set to.