### PR TITLE
fix: move API usage files to API folders

### DIFF
--- a/code/web/interface/themes/responsive/API/dashboard.tpl
+++ b/code/web/interface/themes/responsive/API/dashboard.tpl
@@ -11,7 +11,7 @@
 						<div class="row">
 							<div class="col-sm-10 col-sm-offset-1">
 								<h3 class="dashboardCategoryLabel">{$method}{' '} {* No translation needed *}
-									<a href="/Admin/APIUsageGraphs?stat={$method}&instance={$selectedInstance}" title="{translate text="{$moduleName} Graph" inAttribute="true" isAdminFacing=true}">
+									<a href="/API/UsageGraphs?stat={$method}&instance={$selectedInstance}" title="{translate text="{$moduleName}: {$method} Graph" inAttribute="true" isAdminFacing=true}">
 										<i class="fas fa-chart-line"></i>
 									</a>
 								</h3>

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -72,6 +72,7 @@
 
 ## Aspen Usage Data
 - added usage graphs and raw data tables for the Axis360, Aspen API, and SideLoads usage dashboards, all of which include a CSV download feature. (*CZ*)
+- change the urls for the API Usage Dashboard and API Usage graphs from /Admin/APIUsageDashboard to /API/UsageDashboard and /Admin/APIUsageGraphs to /API/UsageGraphs respectively. (*CZ*)
 
 ### Greenhouse Updates
 - Add the ability to generate historical reading history data for a patron. Reading history can be generated for the past 1–6 years with a minimum and maximum number of reading history entries per month. Entries are generated at random from the grouped works in the database. The new tool is located at Greenhouse > Testing Tools > Generate Reading History. (*MDN*)

--- a/code/web/services/API/AJAX.php
+++ b/code/web/services/API/AJAX.php
@@ -1,0 +1,10 @@
+<?php
+require_once ROOT_DIR . '/JSON_Action.php';
+
+class API_AJAX extends JSON_Action {
+	public function exportUsageData() {
+		require_once ROOT_DIR . '/services/API/UsageGraphs.php';
+		$aspenUsageGraph = new API_UsageGraphs();
+		$aspenUsageGraph->buildCSV();
+	}
+}

--- a/code/web/services/API/UsageDashboard.php
+++ b/code/web/services/API/UsageDashboard.php
@@ -2,7 +2,7 @@
 require_once ROOT_DIR . '/services/Admin/Dashboard.php';
 require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 
-class Admin_APIUsageDashboard extends Admin_Dashboard {
+class API_UsageDashboard extends Admin_Dashboard {
 	function launch() {
 		global $interface;
 
@@ -24,7 +24,7 @@ class Admin_APIUsageDashboard extends Admin_Dashboard {
 
 		$interface->assign('statsByModule', $statsByModule);
 
-		$this->display('api_usage_dashboard.tpl', 'Aspen Usage Dashboard');
+		$this->display('dashboard.tpl', 'Aspen Usage Dashboard');
 	}
 
 	/**

--- a/code/web/services/API/UsageGraphs.php
+++ b/code/web/services/API/UsageGraphs.php
@@ -3,7 +3,7 @@
 require_once ROOT_DIR . '/services/Admin/Admin.php';
 require_once ROOT_DIR . '/sys/SystemLogging/APIUsage.php';
 
-class Admin_APIUsageGraphs extends Admin_Admin
+class API_UsageGraphs extends Admin_Admin
 {
 	function launch()
 	{
@@ -17,7 +17,7 @@ class Admin_APIUsageGraphs extends Admin_Admin
 		}
 
 		$title = 'Aspen Discovery API Usage Graph';
-		$interface->assign('section', 'Admin');
+		$interface->assign('section', 'API');
 		$interface->assign('showCSVExportButton', true);
 		$interface->assign('graphTitle', $title);
 		$this->assignGraphSpecificTitle($stat);
@@ -25,7 +25,7 @@ class Admin_APIUsageGraphs extends Admin_Admin
 		$interface->assign('stat', $stat);
 		$interface->assign('propName', 'exportToCSV');
 		$title = $interface->getVariable('graphTitle');
-		$this->display('usage-graph.tpl', $title);
+		$this->display('../Admin/usage-graph.tpl', $title);
 	}
 	function getBreadcrumbs(): array
 	{

--- a/code/web/services/Admin/AJAX.php
+++ b/code/web/services/Admin/AJAX.php
@@ -1664,20 +1664,9 @@ class Admin_AJAX extends JSON_Action {
 		return $result;
 	}
 
-	/*	Aspen API Usage and general Aspen usage use the same graph template and AJAX file,
-		but different services.
-		This is reflected in the following control flow
-	*/
 	public function exportUsageData() {
-		$stat = $_REQUEST['stat'];
-
-		if ($stat == 'runPendingDatabaseUpdates') {
-			require_once ROOT_DIR . '/services/Admin/APIUsageGraphs.php';
-			$aspenUsageGraph = new Admin_APIUsageGraphs();
-		} else {
-			require_once ROOT_DIR . '/services/Admin/UsageGraphs.php';
-			$aspenUsageGraph = new Admin_UsageGraphs();
-		}
+		require_once ROOT_DIR . '/services/Admin/UsageGraphs.php';
+		$aspenUsageGraph = new Admin_UsageGraphs();
 		$aspenUsageGraph->buildCSV();
 	}
 }

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3640,7 +3640,7 @@ class User extends DataObject {
 			'View Dashboards',
 			'View System Reports',
 		]);
-		$sections['system_reports']->addAction(new AdminAction('API Usage Dashboard', 'API Usage Report for Aspen Discovery.', '/Admin/APIUsageDashboard'), [
+		$sections['system_reports']->addAction(new AdminAction('API Usage Dashboard', 'API Usage Report for Aspen Discovery.', '/API/UsageDashboard'), [
 			'View Dashboards',
 			'View System Reports',
 		]);


### PR DESCRIPTION
BUG (in 24.10.00): In https://github.com/PTFS-Europe/aspen-discovery/pull/126, for Aspen Administration > System Reports > API Usage Dashboards, only the  'runPendingDatabaseUpdates' data could be successfully exported as a CSV due to a hard-coded bit of control flow in `services/Admin/AJAX.php`.
________________________________________________________

Keeping the dashboard and usage graph service files for APIs in the Admin folder would have created the need for additional parameters and control flow logic in the exportUsageData method which both Admin usage data CSV export and API usage data CSV export relied on. Additionally, their class names did not follow the same naming conventions (_Dashboard and_UsageGraphs) as the other usage dashboards and graphs classes now tend to do in Aspen.

This refactor provides some additional separation of concerns by replacing `services/Admin/APIUsageDashboard.php` and `services/Admin/APIUsageGraphs.php` with  `services/API/Dashboard.php` and `services/API/UsageGraphs`, thereby fixing the csv export issue.

**Expected behaviour post-patch:**

- the CSV export now works for any usage graph (not only 'runPendingDatabaseUpdates'), so that the dowloaded CSV contains data, and that data matches the selected usage stat.
- the title of the link to the usage graph pages now also include the name of the method (stat).
- the urls for the API Usage Dashboard and API Usage graphs change from `/Admin/APIUsageDashboard` to `/API/UsageDashboard` and  `/Admin/APIUsageGraphs` to `/API/UsageGraphs`

**Test plan:**

0) ensure that api_usage is populated by more than one module and more than one method. Out of the box adb only tends to show 'runPendingDatabaseUpdates' for the 'SystemAPI' module. If not, insert additional mock data (e.g  INSERT INTO api_usage values (2,2024,8,'2024-8','UserAPI', 'updateNotificationOnboardingStatus', 12);)

1) Log in to Aspen as an Admin
2) In Aspen Administration > System Reports, open API Usage Dashboard. Notice the title of the links match their section and header.
3) For each API and for each of their stats, open their usage graph page. Notice that the data matches the data on the dashboard, both in the raw data table and on the graph. Also notice that the title of the graph match its section and header in the dashboard.
4) Click 'Export to CSV' (bottom left of the page) to check that the downloaded file's contents match
 those of the raw data table and that its name includes the stat name.

To replicate the bug, follow this test plan on a 24.10.00-based branch without applying the patch. After applying, navigate back to the Aspen Administration menu page and access the API Usage Dashboard from the link there (notice the change in url). 
