### PR TITLE
24.11.00 grapes page title control

### DIFF
--- a/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
+++ b/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
@@ -8,7 +8,9 @@
     <title>{$title|escape: 'html'}</title>
   </head>
   <body>
-    <h1>{$title|escape: 'html'}</h1>
+    {if $showTitleOnPage}
+      <h1>{$title|escape: 'html'}</h1>
+    {/if}
     <div id="content">
       {$templateContent}
     </div>

--- a/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
+++ b/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     {if $canEdit}
-      <div style="position:absolute;top:50px;right:10px"><button onclick="window.location.href='{$editPageUrl|escape: 'html'}'">{translate text="Edit Page" isPublicFacing=false}</button></div>
+      <div style="position:absolute;top:30px;right:10px"><button onclick="window.location.href='{$editPageUrl|escape: 'html'}'">{translate text="Edit Page" isPublicFacing=false}</button></div>
     {/if}
     <title>{$title|escape: 'html'}</title>
   </head>

--- a/code/web/release_notes/24.11.00.MD
+++ b/code/web/release_notes/24.11.00.MD
@@ -1,0 +1,3 @@
+## Aspen Discovery Updates
+### Web Builder - Grapes JS Updates
+- Add the ability for users to control whether the title they assign to their Grapes JS pages is displayed when viewing as a page. (*AB*)

--- a/code/web/services/WebBuilder/GrapesPage.php
+++ b/code/web/services/WebBuilder/GrapesPage.php
@@ -40,6 +40,7 @@ class WebBuilder_GrapesPage extends Action {
 		global $interface;
 
 		$title = $this->grapesPage->title;
+		$showTitleOnPage = $this->grapesPage->showTitleOnPage;
 		$interface->assign('id', $this->grapesPage->id);
 		$interface->assign('contents', $this->grapesPage->getFormattedContents());
 		$editButton = $this->generateEditPageUrl();
@@ -58,6 +59,7 @@ class WebBuilder_GrapesPage extends Action {
 		}
 		$interface->assign('templateContent', $templateContent);
 		$interface->assign('title', $title);
+		$interface->assign('showTitleOnPage', $showTitleOnPage);
 
 		$this->display('grapesPage.tpl', $title, '', false);
 	}
@@ -68,7 +70,7 @@ class WebBuilder_GrapesPage extends Action {
 
 	function generateEditPageUrl() {
 		$objectId = $this->grapesPage->id;
-		$templatesSelect - $this->grapesPage->templatesSelect;
+		$templatesSelect = $this->grapesPage->templatesSelect;
 		return '/services/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $objectId . '&tempalteId=' . $templatesSelect;
 	}
 

--- a/code/web/sys/DBMaintenance/version_updates/24.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.11.00.php
@@ -1,0 +1,16 @@
+<?php
+
+function getUpdates24_11_00(): array {
+    $curTime = time();
+    return [
+        //alexander - PTFS Europe
+		'optional_show_title_on_grapes_pages' => [
+			'title' => 'Optional Show Title On Grapes Pages',
+			'description' => 'Make displaying a given title on a grapes page optional',
+			'continueOnError' => false,
+			'sql' => [
+				'ALTER TABLE grapes_web_builder ADD COLUMN showTitleOnPage TINYINT NOT NULL DEFAULT 1'
+			],
+		],//optional_show_title_on_grapes_pages
+    ];
+}

--- a/code/web/sys/WebBuilder/GrapesPage.php
+++ b/code/web/sys/WebBuilder/GrapesPage.php
@@ -7,6 +7,7 @@ class GrapesPage extends DB_LibraryLinkedObject {
 	public $__table = 'grapes_web_builder';
 	public $id;
 	public $title;
+	public $showTitleOnPage;
 	public $urlAlias;
 	public $teaser;
 	public $templatesSelect;
@@ -45,6 +46,14 @@ class GrapesPage extends DB_LibraryLinkedObject {
 				'size' => '40',
 				'maxLength' => 100,
 				'required' => true,
+			],
+			//TODO:: Add showTitleOnPage to db table for grapes page and add conditional check on .tpl file
+			'showTitleOnPage' => [
+				'property' => 'showTitleOnPage',
+				'type' => 'checkbox',
+				'label' => 'Display Title on Page',
+				'description' => 'Whether or not to display the title on the Grapes Page',
+				'default' => 1,
 			],
 			'urlAlias' => [
 				'property' => 'urlAlias',


### PR DESCRIPTION
Allow users to control whether the title they have assigned to their grapes page is displayed when the page is viewed. 

https://aspen-discovery.atlassian.net/jira/software/c/projects/DIS/issues/DIS-32?jql=project%20%3D%20%22DIS%22%20ORDER%20BY%20created%20DESC


TEST PLAN:

Ensure the Web Builder Module is active System Administration->Modules->Web Builder.
Ensure Grapes JS is enabled System Administration->System Variables->Enable Grapes Editor.
Create a Grapes Page Web Builder->Grapes Pages->Add New Ensure the new page has a title and the Display Title on Page box is ticked.
Add some basic content e.g. a heading to the page by clicking open in editor.
Save the page and use the Breadcrumbs to navigate back to Grapes Pages and choose 'View as Page.'
Note that the title you gave the page when you created it is in the UI.
Return to your list of pages using the breadcrumbs and select 'edit.'
Uncheck the Display Title on Page box and save.
Return to the list and then select 'View as Page.' Notice that your page still displays but the title no longer appears in the UI.