### PR TITLE
24.10.00 handle eds search error

### DIFF
--- a/code/web/interface/themes/responsive/EBSCO/searchError.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/searchError.tpl
@@ -10,10 +10,10 @@
 	</div>
 	{/if}
 
-	{if !empty($searchError) && !empty($searchError.error.msg)}
+	{if !empty($searchError) && !empty($searchError->getMessage())}
 		<h2>{translate text="Error description" isPublicFacing=true}</h2>
 		<div>
-			{$searchError.error.msg}
+			{$searchError->getMessage()}
 		</div>
 	{/if}
 </div>

--- a/code/web/release_notes/24.10.00.MD
+++ b/code/web/release_notes/24.10.00.MD
@@ -173,6 +173,7 @@
 - E-commerce: SnapPay: drop unused database field and other small fixes. (*JStaub*)
 - Correct cron artifact within new default intellij project. (*MDN*)
 - When batch updating enumerations, display the label for the new value rather than the internal value. (*MDN*)
+- Fix an issue where EBSCO EDS search errors were echoed to the UI on the search page (visible to any visitor) by adding the error message to the logs instead. (*CZ*)
 
 ## This release includes code contributions from
 ###ByWater Solutions

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -126,6 +126,7 @@ class SearchObject_EbscoEdsSearcher extends SearchObject_BaseSearcher {
 	}
 
 	public function authenticate() {
+		global $logger;
 		if (SearchObject_EbscoEdsSearcher::$authenticationToken == null) {
 			global $library;
 			$settings = $this->getSettings();
@@ -185,12 +186,12 @@ BODY;
 							//echo("Authenticated in EDS!");
 							return true;
 						} elseif ($createSessionResponse->ErrorDescription) {
-							echo("create session failed, " . print_r($createSessionResponse));
+							$logger->log("create session failed, " . print_r($createSessionResponse, true), Logger::LOG_WARNING);
 							return new AspenError("Error processing search in EBSCO EDS");
 						}
 					}
 				} else {
-					echo("Authentication failed!, $return");
+					$logger->log("Error processing search in EBSCO EDS: " . print_r($return, true), Logger::LOG_WARNING);
 					return new AspenError("Error processing search in EBSCO EDS: Authentication failed");
 				}
 			} else {

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -186,12 +186,12 @@ BODY;
 							return true;
 						} elseif ($createSessionResponse->ErrorDescription) {
 							echo("create session failed, " . print_r($createSessionResponse));
-							return false;
+							return new AspenError("Error processing search in EBSCO EDS");
 						}
 					}
 				} else {
 					echo("Authentication failed!, $return");
-					return false;
+					return new AspenError("Error processing search in EBSCO EDS: Authentication failed");
 				}
 			} else {
 				return false;
@@ -553,8 +553,12 @@ BODY;
 	}
 
 	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) {
-		if (!$this->authenticate()) {
+		$isAuthenticated = $this->authenticate();
+		if (empty($isAuthenticated)) {
 			return null;
+		}
+		if (get_class($isAuthenticated) == 'AspenError') {
+			return $isAuthenticated;
 		}
 
 		$this->startQueryTimer();


### PR DESCRIPTION
  EDS errors should be logged and not echoed, and a standard Aspen Error should be displayed to the user.
  
  Test plan: see commit messages