### PR TITLE
feat: error messages are specific

### DIFF
--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -187,12 +187,12 @@ BODY;
 							return true;
 						} elseif ($createSessionResponse->ErrorDescription) {
 							$logger->log("create session failed, " . print_r($createSessionResponse, true), Logger::LOG_WARNING);
-							return new AspenError("Error processing search in EBSCO EDS");
+							return new AspenError("EBSCO EDS Authentication failed");
 						}
 					}
 				} else {
-					$logger->log("Error processing search in EBSCO EDS: " . print_r($return, true), Logger::LOG_WARNING);
-					return new AspenError("Error processing search in EBSCO EDS: Authentication failed");
+					$logger->log("EBSCO EDS Authentication failed: " . print_r($return, true), Logger::LOG_WARNING);
+					return new AspenError("EBSCO EDS Authentication failed");
 				}
 			} else {
 				return false;
@@ -661,12 +661,12 @@ BODY;
 					$logger->log(print_r($curlInfo(true)), Logger::LOG_WARNING);
 				}
 				$this->lastSearchResults = false;
-				return new AspenError("Error processing search in EBSCO EDS");
+				return new AspenError("Could not process search in EBSCO EDS");
 			}
 		} catch (Exception $e) {
 			global $logger;
-			$logger->log("Error loading data from EBSCO $e", Logger::LOG_ERROR);
-			return new AspenError("Error loading data from EBSCO $e");
+			$logger->log("Error loading data from EBSCO EDS: $e", Logger::LOG_ERROR);
+			return new AspenError("Could not load data from EBSCO EDS");
 		}
 	}
 


### PR DESCRIPTION
Requested change: error messages should be more specific
_________________________________________________
Error messages should narrow down the cause
to whether the pertain to authentication, issues
loading data from EDS, or processing the search,
and do so without risking to expose any data that
should not be made publicly visible.

Test plan:

- navigate to Aspen Administration > EBSCO EDS > Settings
- create a new Setting, make sure to use invalid credentials and save
- navigate to Aspen Administration > Primary Configuration > Library Systems and select your
current Library
- set its EDS Setting to the setting you just created
- log out
- run a search in Articles and Databases

Before this commit, the error message will
indicate that the EDS search failed. After this,
it will indicate that it failed due to an
EDS authentication issue.

Note: this also removes the possibility for errors thrown during the search processing to be show to
the end user directly - they are logged instead.