### PR TITLE
refactor: Add Authorization Check to saveToList

### DIFF
--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -7085,7 +7085,7 @@ class MyAccount_AJAX extends JSON_Action {
 				$totalRecords = 0;
 			} else {
 				$userList->id = $listId;
-				$totalRecords = $userList->numValidListItems();
+				// $totalRecords = $userList->numValidListItems();
 				if (!$userList->find(true)) {
 					$result['success'] = false;
 					$result['message'] = translate([
@@ -7093,6 +7093,17 @@ class MyAccount_AJAX extends JSON_Action {
 						'isPublicFacing' => true,
 					]);
 					$listOk = false;
+				} else {
+						//Authorization check: Ensure list belongs to logged in user
+					if ($userList->user_id != UserAccount::getActiveUserId()) {
+						$result['success'] = false;
+						$result['message'] =translate([
+							'text' => 'You are not authorized to modify this list.',
+							'isPublicFacing' => true,
+						]);
+						return $result;
+					}
+					$totalRecords = $userList->numValidListItems();
 				}
 			}
 


### PR DESCRIPTION
A bug has been reported where user can add to the list of another user. 
TEST PLAN: 
Prior to Applying Patch:
Replicate the bug:
1. Log into Aspen and go to your account, select Masquerade and Masquerade as Library card user number 42. 
2. Create a list. 
3. Carry out a search and select a book, click add to list. Use the developer tools to take notice of the id of the list you are adding to and note it down. 
4. End your masquerade and create a list as Aspen_Admin. 
5. Use the search function and add a different book to your list. 
6. In the Dev Tool, use the Network tab to navigate to the saveToList method and right click. 
7. Select Edit and Resend
8. In the Network console, alter the list id number to the one you noted down and click send. 
9. Masquerade as library card number 42 again and check your list, the second book will now be part of this list too. 
APPLY THE PATCH
Repeat the steps above, this time when you select 'send' you should see in the body section that success is false and that you are not authorized to edit this list.  