### PR TITLE
24.12.00 grapes js remove edit button

### DIFF
--- a/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
+++ b/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
@@ -2,9 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    {if $canEdit}
-      <div style="position:absolute;top:50px;right:10px"><button onclick="window.location.href='{$editPageUrl|escape: 'html'}'">{translate text="Edit Page" isPublicFacing=false}</button></div>
-    {/if}
     <title>{$title|escape: 'html'}</title>
   </head>
   <body>

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -12,6 +12,8 @@
 // james staub - Nashville
 
 // alexander - PTFSE
+### Web Builder Updates 
+- Remove edit button in admin view of Grapes JS Pages as breadcrumbs allow navigation back to the editor and are in keeping with the rest of Aspen. (*AB*)
 
 // Chloe - PTFSE
 

--- a/code/web/services/WebBuilder/GrapesPage.php
+++ b/code/web/services/WebBuilder/GrapesPage.php
@@ -42,8 +42,6 @@ class WebBuilder_GrapesPage extends Action {
 		$title = $this->grapesPage->title;
 		$interface->assign('id', $this->grapesPage->id);
 		$interface->assign('contents', $this->grapesPage->getFormattedContents());
-		$editButton = $this->generateEditPageUrl();
-		$interface->assign('editPageUrl', $editButton);
 		$canEdit = UserAccount::userHasPermission(	'Administer All Grapes Pages',
 		'Administer Library Grapes Pages');
 		$interface->assign('canEdit', $canEdit);
@@ -66,11 +64,6 @@ class WebBuilder_GrapesPage extends Action {
 		return true;
 	}
 
-	function generateEditPageUrl() {
-		$objectId = $this->grapesPage->id;
-		$templatesSelect - $this->grapesPage->templatesSelect;
-		return '/services/WebBuilder/GrapesJSEditor?objectAction=edit&id=' . $objectId . '&tempalteId=' . $templatesSelect;
-	}
 
 	function getBreadcrumbs(): array {
 		$breadcrumbs = [];


### PR DESCRIPTION
https://aspen-discovery.atlassian.net/jira/software/c/projects/DIS/issues/DIS-33?jql=project%20%3D%20%22DIS%22%20ORDER%20BY%20created%20DESC

Remove Edit button from grapes view as page as the editor can be accessed through the breadcrumbs and this option is more in keeping with the rest of Aspen.

TEST PLAN:

Ensure Web Builder is enabled System Administration->Modules->Web Builder.
Ensure that Grapes JS is enabled System Administration->System Variables-> Enable Grapes Editor
Prior to applying patch:
Navigate to Web Builder->Grapes Pages and select Add new.
Create a page and click Open in Editor.
Add some content using Grapes JS.
Ensure you save the page.
Navigate back to the list of pages using the breadcrumbs at the top of the editor. Click view as page.
Notice that there is an "Edit Page" button on the page and that this takes you back to the gjs editor, as does the "Edit" option in the breadcrumbs.
Apply Patch
Navigate back to 'View As Page' and notice that the 'Edit Page' button has been removed.
The 'Edit' option in the breadcrumbs still allows you to navigate back to the gjs editor for the current page.