### PR TITLE
24.12.00 subdomain tooltip

### DIFF
--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -67,6 +67,7 @@
 
 ### Other Updates
 - Redirect to selfRegistrationUrl if the /MyAccount/SelfReg URL is accessed directly.(*PA*)
+- The subdomain tooltip now informs the user that it must match the subdomain part of the base URL provided. (*CZ*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -952,7 +952,7 @@ class Library extends DataObject {
 				'property' => 'subdomain',
 				'type' => 'text',
 				'label' => 'Subdomain',
-				'description' => 'A unique id to identify the library within the system',
+				'description' => 'A unique id to identify the library within the system. This much match the base URL subdomain used.',
 				'uniqueProperty' => true,
 				'forcesReindex' => true,
 				'required' => true,


### PR DESCRIPTION
 It was discovered that the user-entered value
 in the subdomain field must match the first part
 of the Base Url string.
    
 The tooltip for the subdomain field should
 inform the user of this requirement. 
 
 To test, log in as an administrator, then 
 navigate to /Admin/Libraries, click to edit a library,
 and hover over the tooltip/hint (?) for 
 the subdomain field.
    