### PR TITLE
Libkey integration

### DIFF
--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -2,7 +2,7 @@
 
 class LibKeyDriver {
 
-	public function getLibKeyLink($doi) {
+	public function getLibKeyLink(string $doiUrl): string | null {
 		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
 		$activeLibrary = Library::getActiveLibrary();
 		$settings = new LibKeySetting();
@@ -11,10 +11,14 @@ class LibKeyDriver {
 			$settings->fetch();
 		}
 		$curlWrapper = new CurlWrapper;
-		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $doi . "?access_token=" . $settings->apiKey);
+		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $this->extractDoi($doiUrl) . "?access_token=" . $settings->apiKey);
 		if (empty($response)) {
 			return null;
 		}
 		return json_decode($response, true)["data"]["bestIntegratorLink"]["bestLink"];
+	}
+	public function extractDoi(string $url): string {
+		$doi = str_replace(["https://doi.org/", "http://"], "", $url);
+		return $doi;
 	}
 }

--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -1,0 +1,20 @@
+<?php
+
+class LibKeyDriver {
+
+	public function getLibKeyLink($doi) {
+		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
+		$activeLibrary = Library::getActiveLibrary();
+		$settings = new LibKeySetting();
+		$settings->whereAdd("id=$activeLibrary->libKeySettingId");
+		if ($settings->find(true)) {
+			$settings->fetch();
+		}
+		$curlWrapper = new CurlWrapper;
+		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $doi . "?access_token=" . $settings->apiKey);
+		if (empty($response)) {
+			return null;
+		}
+		return json_decode($response, true)["data"]["bestIntegratorLink"]["bestLink"];
+	}
+}

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1064,7 +1064,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 					}
 				}
 
-				$this->_actions[$variationId] = array_merge($this->_actions[$variationId], $this->createActionsFromUrls($relatedUrls, null, $variationId));
+				$this->_actions[$variationId] = array_merge($this->_actions[$variationId], $this->createActionsFromUrls($relatedUrls, $relatedRecord, $variationId));
 
 				if ($interface->getVariable('displayingSearchResults')) {
 					$showHoldButton = $interface->getVariable('showHoldButtonInSearchResults');
@@ -1314,6 +1314,14 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		$i = 0;
 		if (count($relatedUrls) > 1) {
 			//We will show a popup to let people choose the URL they want
+			foreach($relatedUrls as $relatedUrl) {
+				$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
+				if (!empty($libKeyLink)) {
+					$libKeyRelatedUrl = $relatedUrl;
+					$libKeyrelatedUrl['url'] = $libKeyLink;
+					$relatedUrls[] = $libKeyRelatedUrl;
+				}
+			}
 			$title = translate([
 				'text' => 'Access Online',
 				'isPublicFacing' => true,
@@ -1328,34 +1336,52 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				'target' => '_blank',
 			];
 		} elseif (count($relatedUrls)  == 1) {
-			$urlInfo = reset($relatedUrls);
 
-			//Revert to access online per Karen at CCU.  If people want to switch it back, we can add a per library switch
-			$title = translate([
-				'text' => 'Access Online',
-				'isPublicFacing' => true,
-			]);
-			$alt = 'Available online from ' . $urlInfo['source'];
-			$action = $configArray['Site']['url'] . '/' . $this->getModule() . '/' . $this->id . "/AccessOnline?index=$i&variationId=$variationId";
-			$fileOrUrl = isset($urlInfo['url']) ? $urlInfo['url'] : $urlInfo['file'];
-			if (strlen($fileOrUrl) > 0) {
-				if (strlen($fileOrUrl) >= 3) {
-					$extension = strtolower(substr($fileOrUrl, strlen($fileOrUrl), 3));
-					if ($extension == 'pdf') {
-						$title = translate([
-							'text' => 'Access PDF',
-							'isPublicFacing' => true,
-						]);
-					}
-				}
+			$libKeyLink = $this->getLibKeyUrl($relatedUrls[0]['url']);
+			if (!empty($libKeyLink)) {
+				$title = translate([
+					'text' => 'Access Online',
+					'isPublicFacing' => true,
+				]);
 				$actions[] = [
-					'url' => $action,
-					'redirectUrl' => $fileOrUrl,
 					'title' => $title,
+					'url' => $libKeyLink,
 					'requireLogin' => false,
-					'alt' => $alt,
+					'type' => 'access_online',
+					'id' => "accessOnline_{$this->getId()}",
 					'target' => '_blank',
 				];
+	
+			} else {
+				$urlInfo = reset($relatedUrls);
+
+				//Revert to access online per Karen at CCU.  If people want to switch it back, we can add a per library switch
+				$title = translate([
+					'text' => 'Access Online',
+					'isPublicFacing' => true,
+				]);
+				$alt = 'Available online from ' . $urlInfo['source'];
+				$action = $configArray['Site']['url'] . '/' . $this->getModule() . '/' . $this->id . "/AccessOnline?index=$i&variationId=$variationId";
+				$fileOrUrl = isset($urlInfo['url']) ? $urlInfo['url'] : $urlInfo['file'];
+				if (strlen($fileOrUrl) > 0) {
+					if (strlen($fileOrUrl) >= 3) {
+						$extension = strtolower(substr($fileOrUrl, strlen($fileOrUrl), 3));
+						if ($extension == 'pdf') {
+							$title = translate([
+								'text' => 'Access PDF',
+								'isPublicFacing' => true,
+							]);
+						}
+					}
+					$actions[] = [
+						'url' => $action,
+						'redirectUrl' => $fileOrUrl,
+						'title' => $title,
+						'requireLogin' => false,
+						'alt' => $alt,
+						'target' => '_blank',
+					];
+				}
 			}
 		} else {
 			foreach ($relatedUrls as $urlInfo) {
@@ -1391,6 +1417,11 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		return $actions;
 	}
 
+	private function getLibKeyUrl($doiUrl) {
+		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
+		$libKeyDriver = new LibKeyDriver();
+		return $libKeyDriver->getLibKeyLink($doiUrl);
+	}
 
 	private $catalogDriver = null;
 
@@ -1659,6 +1690,10 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$interface->assign('periodicalIssues', $issues);
 		}
 		$links = $this->getLinks();
+		$libKeyLink = $this->getLibKeyUrl($links[0]['url']);
+		if (!empty($libKeyLink)) {
+			$links[] = ['title' => $libKeyLink, 'url' => $libKeyLink];
+		}
 		$interface->assign('links', $links);
 		$interface->assign('show856LinksAsTab', $library->getGroupedWorkDisplaySettings()->show856LinksAsTab);
 		$interface->assign('showItemDueDates', $library->getGroupedWorkDisplaySettings()->showItemDueDates);

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -45,6 +45,12 @@
 // alexander - PTFSE
 
 // Chloe - PTFSE
+- LibKey (ThirdIron) integration:
+  - Add LibKey Settings under Third Party Enhancement (*CZ*)
+  - LibKey Settings can be associated with specific libraries (*CZ*)
+  - Add an 'Administer LibKey Settings' permission (*CZ*)
+  - For eContent records with DOIs, the 'Access Online' button will default to a LibKey-issued direct link to the document if the active library has a LibKey subscription and if the record is found by LibKey (*CZ*)
+  - LibKey links are also added under 'Links' on the detailed view for a record (*CZ*)
 
 // Lucas - Theke
 

--- a/code/web/services/Admin/LibKeySettings.php
+++ b/code/web/services/Admin/LibKeySettings.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
+
+class Admin_LibKeySettings extends ObjectEditor {
+	function getObjectType(): string {
+		return 'LibKeySetting';
+	}
+
+	function getToolName(): string {
+		return 'LibKeySettings';
+	}
+
+	function getModule(): string {
+		return 'LibKey';
+	}
+
+	function getPageTitle(): string {
+		return 'LibKey Settings';
+	}
+
+	function getAllObjects($page, $recordsPerPage): array {
+		$object = new LibKeySetting();
+		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
+		$this->applyFilters($object);
+		$object->orderBy($this->getSort());
+		$object->find();
+		$objectList = [];
+		while ($object->fetch()) {
+			$objectList[$object->id] = clone $object;
+		}
+		return $objectList;
+	}
+
+	function getDefaultSort(): string {
+		return 'name asc';
+	}
+
+	function getObjectStructure($context = ''): array {
+		return LibKeySetting::getObjectStructure($context);
+	}
+
+	function getPrimaryKeyColumn(): string {
+		return 'id';
+	}
+
+	function getIdKeyColumn(): string {
+		return 'id';
+	}
+
+	function getAdditionalObjectActions($existingObject): array {
+		return [];
+	}
+
+	function getInstructions(): string {
+		return 'https://help.aspendiscovery.org/help/integration/enrichment';
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#third_party_enrichment', 'Third Party Enrichment');
+		$breadcrumbs[] = new Breadcrumb('/Admin/LibKeySettings', 'LibKey Settings');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'third_party_enrichment';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission('Administer LibKey Settings');
+	}
+}

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1996,10 +1996,18 @@ class Record_AJAX extends Action {
 				if ($item->itemId == $itemId) {
 					$relatedUrls = $item->getRelatedUrls();
 					foreach ($relatedUrls as $relatedUrl) {
-						return [
-							'success' => true,
-							'url' => $relatedUrl['url']
-						];
+						$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
+						if (!empty($libKeyLink)) {
+							return [
+								'success' => true,
+								'url' => $libKeyLink
+							];
+						} else {
+							return [
+								'success' => true,
+								'url' => $relatedUrl['url']
+							];
+						}
 					}
 				}
 			}
@@ -2017,4 +2025,11 @@ class Record_AJAX extends Action {
 			'modalButtons' => "",
 		];
 	}
+
+	private function getLibKeyUrl($doiUrl) {
+		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
+		$libKeyDriver = new LibKeyDriver();
+		return $libKeyDriver->getLibKeyLink($doiUrl);
+	}
 }
+

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3872,6 +3872,10 @@ class User extends DataObject {
 			'Administer All System Messages',
 			'Administer Library System Messages',
 		]);
+		$sections['local_enrichment']->addAction(new AdminAction('System Messages', 'System Messages allow you to display messages to your patrons in specific locations.', '/Admin/SystemMessages'), [
+			'Administer All System Messages',
+			'Administer Library System Messages',
+		]);
 
 		$sections['third_party_enrichment'] = new AdminSection('Third Party Enrichment');
 		$sections['third_party_enrichment']->addAction(new AdminAction('Accelerated Reader Settings', 'Define settings to load Accelerated Reader information directly from Renaissance Learning.', '/Enrichment/ARSettings'), 'Administer Third Party Enrichment API Keys');
@@ -3879,6 +3883,7 @@ class User extends DataObject {
 		$sections['third_party_enrichment']->addAction(new AdminAction('ContentCafe Settings', 'Define settings for ContentCafe integration.', '/Enrichment/ContentCafeSettings'), 'Administer Third Party Enrichment API Keys');
 		$sections['third_party_enrichment']->addAction(new AdminAction('DP.LA Settings', 'Define settings for DP.LA integration.', '/Enrichment/DPLASettings'), 'Administer Third Party Enrichment API Keys');
 		$sections['third_party_enrichment']->addAction(new AdminAction('Google API Settings', 'Define settings for integrating Google APIs within Aspen Discovery.', '/Enrichment/GoogleApiSettings'), 'Administer Third Party Enrichment API Keys');
+		$sections['third_party_enrichment']->addAction(new AdminAction('LibKey Settings', 'Administer LibKey Settings', '/Admin/LibKeySettings'), 'Administer LibKey Settings');
 		$nytSettingsAction = new AdminAction('New York Times Settings', 'Define settings for integrating New York Times Content within Aspen Discovery.', '/Enrichment/NewYorkTimesSettings');
 		$nytListsAction = new AdminAction('New York Times Lists', 'View Lists from the New York Times and manually refresh content.', '/Enrichment/NYTLists');
 		if ($sections['third_party_enrichment']->addAction($nytSettingsAction, 'Administer Third Party Enrichment API Keys')) {

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -87,6 +87,15 @@ function getUpdates24_12_00(): array {
 				"INSERT INTO modules (name) VALUES ('LibKey')",
 			],
 		], // create_libkey_module
+		'create_libkey_permissions' => [
+			'title' => 'Create LibKey Permissions',
+			'description' => 'Add an LibKey permission section containing the Administer LibKey Settings permission',
+			'sql' => [
+				"INSERT INTO permissions (name, sectionName, requiredModule, weight, description) VALUES ( 'Administer LibKey Settings','LibKey','LibKey', 0, 'Allows the user to administer the integration with LibKey')",
+				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Administer LibKey Settings'))",
+			],
+		],// create_libkey_permissions
+
 
 		//James Staub - Nashville Public Library
 

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -95,6 +95,19 @@ function getUpdates24_12_00(): array {
 				"INSERT INTO role_permissions(roleId, permissionId) VALUES ((SELECT roleId from roles where name='opacAdmin'), (SELECT id from permissions where name='Administer LibKey Settings'))",
 			],
 		],// create_libkey_permissions
+		'create_libkey_settings_table' => [
+			'title' => 'Create LibKey Settings Table',
+			'description' => 'Add an LibKey settings table',
+			'sql' => [
+				"CREATE TABLE libkey_settings (
+					id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					name VARCHAR(255) NOT NULL,
+					libraryId VARCHAR(20) NOT NULL,
+					apiKey VARCHAR(255) NOT NULL
+				)",
+				"ALTER TABLE library ADD libKeySettingId INT NOT NULL DEFAULT -1"
+			],
+		],// create_libkey_permissions
 
 
 		//James Staub - Nashville Public Library

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -80,7 +80,13 @@ function getUpdates24_12_00(): array {
 		//alexander - PTFS-Europe
 
 		//chloe - PTFS-Europe
-
+		'create_libkey_module' => [
+			'title' => 'Create LibKey Module',
+			'description' => 'Add LibKey to the list of modules',
+			'sql' => [
+				"INSERT INTO modules (name) VALUES ('LibKey')",
+			],
+		], // create_libkey_module
 
 		//James Staub - Nashville Public Library
 

--- a/code/web/sys/LibKey/LibKeySetting.php
+++ b/code/web/sys/LibKey/LibKeySetting.php
@@ -1,0 +1,128 @@
+<?php
+
+class LibKeySetting extends DataObject {
+	public $__table = 'libkey_settings';
+	public $id;
+	public $name;
+	public $libraryId;
+	public $apiKey;
+
+	private $_libraries;
+
+	function getEncryptedFieldNames(): array {
+		return ['apiKey'];
+	}
+
+	static function getObjectStructure($context = ''): array {
+		$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer All Libraries'));
+		return [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id',
+			],
+			'name' => [
+				'property' => 'name',
+				'type' => 'text',
+				'label' => 'Name',
+				'maxLength' => 50,
+				'description' => 'A name for these settings',
+				'required' => true,
+			],
+			'libraryId' => [
+				'property' => 'libraryId',
+				'type' => 'text',
+				'label' => 'Library ID',
+				'maxLength' => 50,
+				'description' => 'Your LibKey library Id',
+				'required' => true,
+			],
+			'apiKey' => [
+				'property' => 'apiKey',
+				'type' => 'storedPassword',
+				'label' => 'Api Key',
+				'description' => 'Your LibKey API Key.',
+				'hideInLists' => true,
+				'required' => false,
+			],
+			'libraries' => [
+				'property' => 'libraries',
+				'type' => 'multiSelect',
+				'listStyle' => 'checkboxSimple',
+				'label' => 'Libraries',
+				'description' => 'Define libraries that use this setting',
+				'values' => $libraryList,
+				'hideInLists' => true,
+			],
+		];
+	}
+
+	public function __get($name) {
+		if ($name == "libraries") {
+			if (!isset($this->_libraries) && $this->id) {
+				$this->_libraries = [];
+				$obj = new Library();
+				$obj->libKeySettingId = $this->id;
+				$obj->find();
+				while ($obj->fetch()) {
+					$this->_libraries[$obj->libraryId] = $obj->libraryId;
+				}
+			}
+			return $this->_libraries;
+		} else {
+			return parent::__get($name);
+		}
+	}
+
+	public function __set($name, $value) {
+		if ($name == "libraries") {
+			$this->_libraries = $value;
+		} else {
+			parent::__set($name, $value);
+		}
+	}
+
+	public function update($context = '') {
+		$ret = parent::update();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return true;
+	}
+
+	public function insert($context = '') {
+		$ret = parent::insert();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return $ret;
+	}
+
+	public function saveLibraries() {
+		if (isset ($this->_libraries) && is_array($this->_libraries)) {
+			$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer All Libraries'));
+			foreach ($libraryList as $libraryId => $displayName) {
+				$library = new Library();
+				$library->libraryId = $libraryId;
+				$library->find(true);
+				if (in_array($libraryId, $this->_libraries)) {
+					if ($library->libKeySettingId != $this->id) {
+						$library->finePaymentType = 2;
+						$library->libKeySettingId = $this->id;
+						$library->update();
+					}
+				} else {
+					if ($library->libKeySettingId == $this->id) {
+						if ($library->finePaymentType == 2) {
+							$library->finePaymentType = 0;
+						}
+						$library->libKeySettingId = -1;
+						$library->update();
+					}
+				}
+			}
+			unset($this->_libraries);
+		}
+	}
+}

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -479,6 +479,9 @@ class Library extends DataObject {
 	public $shareItUsername;
 	public $shareItPassword;
 
+	// LIBKEY
+	public $libKeySettingId;
+
 	public $allowUpdatingHolidaysFromILS;
 
 	private $_cloudLibraryScope;


### PR DESCRIPTION
Integrates with LibKey so that direct links to documents can be added for any record found through an Aspen Catalogue Search  that has a DOI.

First version of the integration.

Features included:

admin:
- Enable LibKey module
- Administer LibKey setting
- Administer LibKey permission

patrons / admins:
- 'Access Online' takes the user directly to the document if 
  - LibKey is set up for the active library AND
  - the record found in search results has a DOI AND
  - LibKey does return a direct link
  
Future features / features in development: pdf download

See commit messages for test plans.

Note: release notes to be added when version confirmed (24.12.00 or 25.01.00)