### PR TITLE
24.12.00 harvard citations

### DIFF
--- a/code/web/RecordDrivers/EbscoRecordDriver.php
+++ b/code/web/RecordDrivers/EbscoRecordDriver.php
@@ -478,6 +478,8 @@ class EbscoRecordDriver extends RecordInterface {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}

--- a/code/web/RecordDrivers/EbscohostRecordDriver.php
+++ b/code/web/RecordDrivers/EbscohostRecordDriver.php
@@ -533,6 +533,8 @@ class EbscohostRecordDriver extends RecordInterface {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -700,6 +700,8 @@ class GroupedWorkDriver extends IndexRecordDriver {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}
@@ -718,6 +720,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			'ChicagoHumanities',
 			'ChicagoAuthDate',
 			'MLA',
+			'Harvard',
 		];
 	}
 

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -672,6 +672,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 		if (!empty($primary)) {
 			$authors[] = $primary;
 		}
+		$authors = array_unique(array_merge($authors, $this->getContributors()));
 
 		// Collect all details for citation builder:
 		$publishers = $this->getPublishers();

--- a/code/web/RecordDrivers/GroupedWorkSubDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkSubDriver.php
@@ -129,6 +129,8 @@ abstract class GroupedWorkSubDriver extends RecordInterface {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}
@@ -147,6 +149,7 @@ abstract class GroupedWorkSubDriver extends RecordInterface {
 			'ChicagoHumanities',
 			'ChicagoAuthDate',
 			'MLA',
+			'Harvard',
 		];
 	}
 

--- a/code/web/RecordDrivers/IndexRecordDriver.php
+++ b/code/web/RecordDrivers/IndexRecordDriver.php
@@ -336,6 +336,8 @@ abstract class IndexRecordDriver extends RecordInterface {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}

--- a/code/web/RecordDrivers/SummonRecordDriver.php
+++ b/code/web/RecordDrivers/SummonRecordDriver.php
@@ -425,6 +425,8 @@ class SummonRecordDriver extends RecordInterface {
 				return $citation->getChicagoHumanities();
 			case 'MLA':
 				return $citation->getMLA();
+			case 'Harvard':
+				return $citation->getHarvard();
 		}
 		return '';
 	}

--- a/code/web/interface/themes/responsive/Citation/harvard.tpl
+++ b/code/web/interface/themes/responsive/Citation/harvard.tpl
@@ -1,0 +1,5 @@
+{if !empty($citeDetails.authors)}{$citeDetails.authors|escape} {/if}
+{if !empty($citeDetails.year)}({$citeDetails.year|escape}). {/if}
+<span style="font-style:italic;">{$citeDetails.title|escape}</span>
+{if !empty($citeDetails.edition)} {$citeDetails.edition|escape}. {/if}
+{if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}. {/if}

--- a/code/web/interface/themes/responsive/Citation/harvard.tpl
+++ b/code/web/interface/themes/responsive/Citation/harvard.tpl
@@ -1,5 +1,5 @@
-{if !empty($citeDetails.authors)}{$citeDetails.authors|escape} {/if}
-{if !empty($citeDetails.year)}({$citeDetails.year|escape}). {/if}
-<span style="font-style:italic;">{$citeDetails.title|escape}</span>
-{if !empty($citeDetails.edition)} {$citeDetails.edition|escape} {/if}
-{if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}. {/if}
+{if !empty($harvardDetails.authors)}{$harvardDetails.authors|escape} {/if}
+{if !empty($harvardDetails.year)}({$harvardDetails.year|escape}). {/if}
+<span style="font-style:italic;">{$harvardDetails.title|escape}</span>
+{if !empty($harvardDetails.edition)} {$harvardDetails.edition|escape} {/if}
+{if !empty($harvardDetails.publisher)}{$harvardDetails.publisher|escape}. {/if}

--- a/code/web/interface/themes/responsive/Citation/harvard.tpl
+++ b/code/web/interface/themes/responsive/Citation/harvard.tpl
@@ -1,5 +1,5 @@
 {if !empty($citeDetails.authors)}{$citeDetails.authors|escape} {/if}
 {if !empty($citeDetails.year)}({$citeDetails.year|escape}). {/if}
 <span style="font-style:italic;">{$citeDetails.title|escape}</span>
-{if !empty($citeDetails.edition)} {$citeDetails.edition|escape}. {/if}
+{if !empty($citeDetails.edition)} {$citeDetails.edition|escape} {/if}
 {if !empty($citeDetails.publisher)}{$citeDetails.publisher|escape}. {/if}

--- a/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
@@ -39,7 +39,7 @@
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.citethisforme.com/harvard-referencing" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/authors" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>

--- a/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
@@ -39,7 +39,7 @@
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/authors" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>

--- a/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
+++ b/code/web/interface/themes/responsive/ExternalEContent/cite.tpl
@@ -38,13 +38,19 @@
 			</p>
 		{/if}
 
+		{if !empty($harvard)}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.citethisforme.com/harvard-referencing" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
+				{include file=$harvard}
+			</p>
+		{/if}
+
 		{if !empty($mla)}
 			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_general_format.html" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$mla}
 			</p>
 		{/if}
-
 	</div>
 	<div class="alert alert-warning">
 		<strong>{translate text="Note!" isPublicFacing=true}</strong> {translate text="Citations contain only title, author, edition, publisher, and year published. Citations should be used as a guideline and should be double checked for accuracy. Citation formats are based on standards as of August 2021." isPublicFacing=true}

--- a/code/web/interface/themes/responsive/Record/cite.tpl
+++ b/code/web/interface/themes/responsive/Record/cite.tpl
@@ -39,7 +39,7 @@
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.citethisforme.com/harvard-referencing" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/authors" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>

--- a/code/web/interface/themes/responsive/Record/cite.tpl
+++ b/code/web/interface/themes/responsive/Record/cite.tpl
@@ -39,7 +39,7 @@
 		{/if}
 
 		{if !empty($harvard)}
-			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/authors" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://library-guides.ucl.ac.uk/harvard/a-z" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
 				{include file=$harvard}
 			</p>

--- a/code/web/interface/themes/responsive/Record/cite.tpl
+++ b/code/web/interface/themes/responsive/Record/cite.tpl
@@ -38,6 +38,13 @@
 			</p>
 		{/if}
 
+		{if !empty($harvard)}
+			<b>{translate text="Harvard Citation" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://www.citethisforme.com/harvard-referencing" target="_blank" aria-label="{translate text='style guide' isPublicFacing=true} ({translate text='opens in new window' isPublicFacing=true})">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
+			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">
+				{include file=$harvard}
+			</p>
+		{/if}
+
 		{if !empty($mla)}
 			<b>{translate text="MLA Citation, 9th Edition" isPublicFacing=true}</b> {if !empty($showCitationStyleGuides)}<span class="styleGuide"><a href="https://owl.purdue.edu/owl/research_and_citation/mla_style/mla_formatting_and_style_guide/mla_general_format.html" target="_blank">({translate text="style guide" isPublicFacing=true})</a></span>{/if}
 			<p style="width: 95%; padding-left: 25px; text-indent: -25px;">

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -74,6 +74,10 @@
 ### Web Builder Updates 
 - Remove edit button in admin view of Grapes JS Pages as breadcrumbs allow navigation back to the editor and are in keeping with the rest of Aspen. (*AB*)
 
+### Citation Updates
+- Add Harvard Citation style to the list that appears in the citation section on each full record. (*AB*)
+- Add Harvard Citation style to the dropdown list in the 'Generate Citation' section in the lists section. (*AB*)
+
 // Chloe - PTFSE
 
 // Pedro - PTFSE

--- a/code/web/sys/CitationBuilder.php
+++ b/code/web/sys/CitationBuilder.php
@@ -43,8 +43,8 @@ class CitationBuilder {
 			'APA' => 'APA',
 			'ChicagoHumanities' => 'Chicago/Turabian - Humanities',
 			'ChicagoAuthDate' => 'Chicago/Turabian - Author Date',
-			'MLA' => 'MLA',
 			'Harvard' => 'Harvard',
+			'MLA' => 'MLA',
 		];
 	}
 

--- a/code/web/sys/CitationBuilder.php
+++ b/code/web/sys/CitationBuilder.php
@@ -184,7 +184,7 @@ class CitationBuilder {
 			'year' => $this->getHarvardYear(),
 			'edition' => $this->getHarvardEdition(),
 		];
-		$interface->assign('citeDetails', $harvard);
+		$interface->assign('harvardDetails', $harvard);
 		return 'Citation/harvard.tpl';
 	}
 
@@ -390,13 +390,14 @@ class CitationBuilder {
 	 * @return string
 	 */
 	private function convertToSentenceCase($text) {
+
 		$abbreviations = [];
 	
 		//Regex pattern to match common exceptions e.g. "R&B" and "USA"
 		$pattern = '/\b[A-Z&]+\b/';
 		//Generate placeholders for abbreviations that match the pattern
 		$text = preg_replace_callback($pattern, function($matches) use (&$abbreviations) {
-			$placeholder = uniqid('abbr_', true);
+			$placeholder = '[[abbr_' . count($abbreviations) . ']]';
 			$abbreviations[$placeholder] = $matches[0];
 			//Replace abbreviation with placeholder
 			return $placeholder;
@@ -428,7 +429,6 @@ class CitationBuilder {
 		/*if (!((substr($title, -1) == '?') || (substr($title, -1) == '!'))) {
 			$title .= '.';
 		}*/
-
 		return $title;
 	}
 

--- a/code/web/sys/CitationBuilder.php
+++ b/code/web/sys/CitationBuilder.php
@@ -553,9 +553,14 @@ class CitationBuilder {
 			$numAuthors = count($this->details['authors']);
 			foreach($this->details['authors'] as $author) {
 				$author = $this->abbreviateName($author);
+				//After listing 8 authors, stop listing and add 'et al.'
+				if ($i == 7) {
+					$authorStr .= ' et al';
+					break;
+				}
 
 				//Add "and" for last author
-				if (($i +1 == $numAuthors) && ($i > 0)) {
+				if (($i +1 == $numAuthors || $i == 6) && ($i > 0)) {
 					$authorStr .= ' and ' . $this->stripPunctuation($author) . '.';
 				} elseif ($i > 0) {
 					$authorStr .= ', ' . $this->stripPunctuation($author) . '.';
@@ -591,7 +596,6 @@ class CitationBuilder {
 				}
 			}
 		}
-
 		// No edition statement found:
 		return false;
 	}

--- a/code/web/sys/CitationBuilder.php
+++ b/code/web/sys/CitationBuilder.php
@@ -182,7 +182,7 @@ class CitationBuilder {
 			'authors' => $this->getHarvardAuthors(),
 			'publisher' => $this->getPublisher(),
 			'year' => $this->getHarvardYear(),
-			'edition' => $this->getEdition(),
+			'edition' => $this->getHarvardEdition(),
 		];
 		$interface->assign('citeDetails', $harvard);
 		return 'Citation/harvard.tpl';
@@ -593,6 +593,32 @@ class CitationBuilder {
 			} else {
 				if ($this->details['edition'] !== '1st ed.') {
 					return $this->details['edition'];
+				}
+			}
+		}
+		// No edition statement found:
+		return false;
+	}
+
+	/**
+	 * Get edition statement for inclusion in a citation. Used for Harvard functionality.
+	 * 
+	 * @access private
+	 * @return string
+	 */
+	private function getHarvardEdition() {
+		if (isset($this->details['edition'])) {
+			if (is_array($this->details['edition'])) {
+				foreach ($this->details['edition'] as $edition) {
+					if ($edition !== '1st ed.'){
+						$edition =preg_replace('/\bedition\b/i', 'edn', $edition);
+						return $edition;
+					}
+				}
+			} else {
+				if ($this->details['edition'] !== '1st ed.') {
+					$edition = preg_replace('/\bedition\b/i', 'edn', $this->details['edition']);
+					return $edition;
 				}
 			}
 		}


### PR DESCRIPTION
BEFORE APPLYING PATCH:
1) Carry out a search and select an record. Scroll down and expand the 'Citations' section.
2) Note that Harvard style citations are not currently an option
3) Navigate to your account and create a list, add some items to your list. 
4) Navigate back to your list and click the title - click 'Generate Citations', note Harvard is not currently among the options. 

AFTER APPLYING PATCH:
1) Repeat the above and notice that for each record the Harvard Citation is now listed in the Citations section with the other styles. 
2) Note that Harvard citations are available in the generate citations drop down and when selected, citations for the list are now built inline with Harvard citation guidelines. 