### PR TITLE
24.12.00 grapes page title control

### DIFF
--- a/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
+++ b/code/web/interface/themes/responsive/WebBuilder/grapesPage.tpl
@@ -5,7 +5,9 @@
     <title>{$title|escape: 'html'}</title>
   </head>
   <body>
-    <h1>{$title|escape: 'html'}</h1>
+    {if $showTitleOnPage}
+      <h1>{$title|escape: 'html'}</h1>
+    {/if}
     <div id="content">
       {$templateContent}
     </div>

--- a/code/web/release_notes/24.12.00.MD
+++ b/code/web/release_notes/24.12.00.MD
@@ -97,6 +97,7 @@
 
 ### Web Builder Updates 
 - Remove edit button in admin view of Grapes JS Pages as breadcrumbs allow navigation back to the editor and are in keeping with the rest of Aspen. (*AB*)
+- Add the ability for users to control whether the title they assign to their Grapes JS page is displayed when viewing as a page. (*AB*)
 
 // Chloe - PTFSE
 

--- a/code/web/services/WebBuilder/GrapesPage.php
+++ b/code/web/services/WebBuilder/GrapesPage.php
@@ -40,6 +40,7 @@ class WebBuilder_GrapesPage extends Action {
 		global $interface;
 
 		$title = $this->grapesPage->title;
+		$showTitleOnPage = $this->grapesPage->showTitleOnPage;
 		$interface->assign('id', $this->grapesPage->id);
 		$interface->assign('contents', $this->grapesPage->getFormattedContents());
 		$canEdit = UserAccount::userHasPermission(	'Administer All Grapes Pages',
@@ -56,6 +57,7 @@ class WebBuilder_GrapesPage extends Action {
 		}
 		$interface->assign('templateContent', $templateContent);
 		$interface->assign('title', $title);
+		$interface->assign('showTitleOnPage', $showTitleOnPage);
 
 		$this->display('grapesPage.tpl', $title, '', false);
 	}

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -132,6 +132,13 @@ function getUpdates24_12_00(): array {
 				"ALTER TABLE indexing_profiles ADD COLUMN treatItemsAsEcontent VARCHAR(512) DEFAULT 'ebook|ebk|eaudio|evideo|online|oneclick|eaudiobook|download|eresource|electronic resource'",
 			],
 		], //add_treatItemsAsEcontent_field
+		'optional_show_title_on_grapes_pages' => [
+			'title' => 'Optional Show Title on Grapes Pages',
+			'description' => 'Make displaying a given title on a grapes pae optional',
+			'sql' => [
+				'ALTER TABLE grapes_web_builder ADD COLUMN showTitleOnPage TINYINT NOT NULL DEFAULT 1'
+			],
+		], //optional_show_title_on_grapes_pages
 
 		//chloe - PTFS-Europe
 

--- a/code/web/sys/WebBuilder/GrapesPage.php
+++ b/code/web/sys/WebBuilder/GrapesPage.php
@@ -7,6 +7,7 @@ class GrapesPage extends DB_LibraryLinkedObject {
 	public $__table = 'grapes_web_builder';
 	public $id;
 	public $title;
+	public $showTitleOnPage;
 	public $urlAlias;
 	public $teaser;
 	public $templatesSelect;
@@ -45,6 +46,13 @@ class GrapesPage extends DB_LibraryLinkedObject {
 				'size' => '40',
 				'maxLength' => 100,
 				'required' => true,
+			],
+			'showTitleOnPage' => [
+				'property' => 'showTitleOnPage',
+				'type' =>'checkbox',
+				'label' => 'Display Title on Page',
+				'description' => 'Whether or not to display the title on the Grapes Page',
+				'default' => 1,
 			],
 			'urlAlias' => [
 				'property' => 'urlAlias',


### PR DESCRIPTION
Allow users to control whether the title they have assigned to their grapes page is displayed when the page is viewed.

https://aspen-discovery.atlassian.net/jira/software/c/projects/DIS/issues/DIS-32?jql=project%20%3D%20%22DIS%22%20ORDER%20BY%20created%20DESC

TEST PLAN:

Ensure the Web Builder Module is active System Administration->Modules->Web Builder.
Ensure Grapes JS is enabled System Administration->System Variables->Enable Grapes Editor.
Create a Grapes Page Web Builder->Grapes Pages->Add New Ensure the new page has a title and the Display Title on Page box is ticked.
Add some basic content e.g. a heading to the page by clicking open in editor.
Save the page and use the Breadcrumbs to navigate back to Grapes Pages and choose 'View as Page.'
Note that the title you gave the page when you created it is in the UI.
Return to your list of pages using the breadcrumbs and select 'edit.'
Uncheck the Display Title on Page box and save.
Return to the list and then select 'View as Page.' Notice that your page still displays but the title no longer appears in the UI.