### PR TITLE
Libkey integration - requested changes

### DIFF
--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -24,6 +24,6 @@ class LibKeyDriver {
 		return $doi;
 	}
 	public function containsDoi(string $url): bool {
-		return preg_match('/10.\d{4,9}\/[-._;()\/:A-Z0-9]/', $url);
+		return preg_match('/10.\d{4,9}\/[-._;()\/:A-Za-z0-9]/', $url);
 	}
 }

--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -1,14 +1,13 @@
 <?php
 
 class LibKeyDriver {
-
 	public function getLibKeyLink(string $doiUrl): string | null {
 		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
 		$activeLibrary = Library::getActiveLibrary();
 		$settings = new LibKeySetting();
 		$settings->whereAdd("id=$activeLibrary->libKeySettingId");
-		if ($settings->find(true)) {
-			$settings->fetch();
+		if (!$settings->find(true)) {
+			return null;
 		}
 		$curlWrapper = new CurlWrapper;
 		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $this->extractDoi($doiUrl) . "?access_token=" . $settings->apiKey);

--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -2,6 +2,9 @@
 
 class LibKeyDriver {
 	public function getLibKeyLink(string $doiUrl): string | null {
+		if (!$this->containsDoi($doiUrl)) {
+			return null;
+		}
 		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
 		$activeLibrary = Library::getActiveLibrary();
 		$settings = new LibKeySetting();
@@ -19,5 +22,8 @@ class LibKeyDriver {
 	public function extractDoi(string $url): string {
 		$doi = str_replace(["https://doi.org/", "http://"], "", $url);
 		return $doi;
+	}
+	public function containsDoi(string $url): bool {
+		return preg_match('/10.\d{4,9}\/[-._;()\/:A-Z0-9]/', $url);
 	}
 }

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1683,7 +1683,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$interface->assign('periodicalIssues', $issues);
 		}
 		$links = $this->getLinks();
-		if (Library::getActiveLibrary()->libKeySettingId != -1  && !empty($relatedUrls[0]['url'])) {
+		if (Library::getActiveLibrary()->libKeySettingId != -1  && !empty($links[0]['url'])) {
 			$libKeyLink = $this->getLibKeyUrl($links[0]['url']);
 			if (!empty($libKeyLink)) {
 				$links[] = ['title' => $libKeyLink, 'url' => $libKeyLink];

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1330,7 +1330,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			];
 		} elseif (count($relatedUrls)  == 1) {	
 
-			if (Library::getActiveLibrary()->libKeySettingId != -1) {
+			if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($relatedUrls[0]['url'])) {
 				$libKeyLink = $this->getLibKeyUrl($relatedUrls[0]['url']);
 				$title = translate([
 					'text' => 'Access Online',
@@ -1683,7 +1683,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$interface->assign('periodicalIssues', $issues);
 		}
 		$links = $this->getLinks();
-		if (Library::getActiveLibrary()->libKeySettingId != -1) {
+		if (Library::getActiveLibrary()->libKeySettingId != -1  && !empty($relatedUrls[0]['url'])) {
 			$libKeyLink = $this->getLibKeyUrl($links[0]['url']);
 			if (!empty($libKeyLink)) {
 				$links[] = ['title' => $libKeyLink, 'url' => $libKeyLink];

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1328,7 +1328,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				'id' => "accessOnline_{$this->getId()}",
 				'target' => '_blank',
 			];
-		} elseif (count($relatedUrls)  == 1) {	
+		} elseif (count($relatedUrls)  == 1) {
 
 			if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($relatedUrls[0]['url'])) {
 				$libKeyLink = $this->getLibKeyUrl($relatedUrls[0]['url']);
@@ -1338,7 +1338,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				]);
 				$actions[] = [
 					'title' => $title,
-					'url' => $libKeyLink ? $libKeyLink : '',
+					'url' => $libKeyLink ? $libKeyLink : $relatedUrls[0]['url'],
 					'requireLogin' => false,
 					'type' => 'access_online',
 					'id' => "accessOnline_{$this->getId()}",

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1314,14 +1314,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		$i = 0;
 		if (count($relatedUrls) > 1) {
 			//We will show a popup to let people choose the URL they want
-			foreach($relatedUrls as $relatedUrl) {
-				$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
-				if (!empty($libKeyLink)) {
-					$libKeyRelatedUrl = $relatedUrl;
-					$libKeyrelatedUrl['url'] = $libKeyLink;
-					$relatedUrls[] = $libKeyRelatedUrl;
-				}
-			}
+
 			$title = translate([
 				'text' => 'Access Online',
 				'isPublicFacing' => true,
@@ -1335,17 +1328,17 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 				'id' => "accessOnline_{$this->getId()}",
 				'target' => '_blank',
 			];
-		} elseif (count($relatedUrls)  == 1) {
+		} elseif (count($relatedUrls)  == 1) {	
 
-			$libKeyLink = $this->getLibKeyUrl($relatedUrls[0]['url']);
-			if (!empty($libKeyLink)) {
+			if (Library::getActiveLibrary()->libKeySettingId != -1) {
+				$libKeyLink = $this->getLibKeyUrl($relatedUrls[0]['url']);
 				$title = translate([
 					'text' => 'Access Online',
 					'isPublicFacing' => true,
 				]);
 				$actions[] = [
 					'title' => $title,
-					'url' => $libKeyLink,
+					'url' => $libKeyLink ? $libKeyLink : '',
 					'requireLogin' => false,
 					'type' => 'access_online',
 					'id' => "accessOnline_{$this->getId()}",
@@ -1690,9 +1683,11 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 			$interface->assign('periodicalIssues', $issues);
 		}
 		$links = $this->getLinks();
-		$libKeyLink = $this->getLibKeyUrl($links[0]['url']);
-		if (!empty($libKeyLink)) {
-			$links[] = ['title' => $libKeyLink, 'url' => $libKeyLink];
+		if (Library::getActiveLibrary()->libKeySettingId != -1) {
+			$libKeyLink = $this->getLibKeyUrl($links[0]['url']);
+			if (!empty($libKeyLink)) {
+				$links[] = ['title' => $libKeyLink, 'url' => $libKeyLink];
+			}
 		}
 		$interface->assign('links', $links);
 		$interface->assign('show856LinksAsTab', $library->getGroupedWorkDisplaySettings()->show856LinksAsTab);

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1996,7 +1996,7 @@ class Record_AJAX extends Action {
 				if ($item->itemId == $itemId) {
 					$relatedUrls = $item->getRelatedUrls();
 					foreach ($relatedUrls as $relatedUrl) {
-						if (Library::getActiveLibrary()->libKeySettingId != -1) {
+						if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($relatedUrl['url'])) {
 							$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
 							if (!empty($libKeyLink)) {
 								return [

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1996,17 +1996,24 @@ class Record_AJAX extends Action {
 				if ($item->itemId == $itemId) {
 					$relatedUrls = $item->getRelatedUrls();
 					foreach ($relatedUrls as $relatedUrl) {
-						$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
-						if (!empty($libKeyLink)) {
-							return [
-								'success' => true,
-								'url' => $libKeyLink
-							];
+						if (Library::getActiveLibrary()->libKeySettingId != -1) {
+							$libKeyLink = $this->getLibKeyUrl($relatedUrl['url']);
+							if (!empty($libKeyLink)) {
+								return [
+									'success' => true,
+									'url' => $libKeyLink
+								];
+							} else {
+								return [
+									'success' => true,
+									'url' => $relatedUrl['url']
+								];
+							} 
 						} else {
 							return [
 								'success' => true,
 								'url' => $relatedUrl['url']
-							];
+							];	
 						}
 					}
 				}

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3872,10 +3872,6 @@ class User extends DataObject {
 			'Administer All System Messages',
 			'Administer Library System Messages',
 		]);
-		$sections['local_enrichment']->addAction(new AdminAction('System Messages', 'System Messages allow you to display messages to your patrons in specific locations.', '/Admin/SystemMessages'), [
-			'Administer All System Messages',
-			'Administer Library System Messages',
-		]);
 
 		$sections['third_party_enrichment'] = new AdminSection('Third Party Enrichment');
 		$sections['third_party_enrichment']->addAction(new AdminAction('Accelerated Reader Settings', 'Define settings to load Accelerated Reader information directly from Renaissance Learning.', '/Enrichment/ARSettings'), 'Administer Third Party Enrichment API Keys');

--- a/code/web/sys/DBMaintenance/version_updates/24.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/24.12.00.php
@@ -80,13 +80,6 @@ function getUpdates24_12_00(): array {
 		//alexander - PTFS-Europe
 
 		//chloe - PTFS-Europe
-		'create_libkey_module' => [
-			'title' => 'Create LibKey Module',
-			'description' => 'Add LibKey to the list of modules',
-			'sql' => [
-				"INSERT INTO modules (name) VALUES ('LibKey')",
-			],
-		], // create_libkey_module
 		'create_libkey_permissions' => [
 			'title' => 'Create LibKey Permissions',
 			'description' => 'Add an LibKey permission section containing the Administer LibKey Settings permission',


### PR DESCRIPTION
Changes requested after code review, most of them performance-related, namely:
_________________________________________________________________________

- check if a url contains a DOI

-  check for libKey setting
  Only ever use the LibKey integration if a LibKey
  setting is associated with the active library.
  This aims to ensure that the LibKey integration
  code only runs if LibKey has been set up for the
  relevant library.


-  do not proceed if no setting found
    
    Removes an unecessary fetch() call as find(true)
    already executes a fetch(), and changes the
    control flow so that getLibKeyLink() returns
    null early if no setting is found (only move on
    to creating an instance of CurlWrapper if the
    setting was found).


-  remove duplicated lines
    
    These were likely involuntarily duplicated during
    a merge conflict resolution. Remove the redundant
    lines.


-   remove unecessary module
    
    It was established that there is no need for the
    LibKey integration to be a module. This removes
    the SQL that would have added it to the modules
    table in the Aspen database.
    
____________________________________________________________________________

To test: 
- check functionality for eContent with DOI urls (test plans at [3956f87](https://github.com/PTFS-Europe/aspen-discovery/pull/144/commits/3956f87096d909e2cacb7d6c82f4657fc6b9ba96) and [4a1d87a](https://github.com/PTFS-Europe/aspen-discovery/pull/144/commits/4a1d87ab5822b31f9aafe17bd7c59bd4ba880050) )
- check functionality for eContent with urls that do not contain DOIs - must be preserved after applying the patch

