### PR TITLE
25.01.00 custom form permissions

### DIFF
--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -12,6 +12,8 @@
 //james
 
 //alexander
+### Web Builder Updates
+- When adding a form to a custom page, limit the forms displayed in the dropdown to those from the user's own library if their permissions are Administer Library Custom Forms. (*AB*)
 
 //chloe
 


### PR DESCRIPTION
This patch limits the custom forms displayed in the dropdown when adding a custom form to a custom page to those of the user's home library if the user's permissions are set to Administer Library Custom Forms. See test plan on JIRA. 

https://aspen-discovery.atlassian.net/jira/software/c/projects/DIS/issues/DIS-73?filter=reportedbyme&jql=project%20%3D%20%22DIS%22%20AND%20reporter%20IN%20%28currentUser%28%29%29%20ORDER%20BY%20created%20DESC