### PR TITLE
25.01.00 libkey integration ebsco records

### DIFF
--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -1,10 +1,7 @@
 <?php
 
 class LibKeyDriver {
-	public function getLibKeyLink(string $doiUrl): string | null {
-		if (!$this->containsDoi($doiUrl)) {
-			return null;
-		}
+	public function getLibKeyLink($data): string | null {
 		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
 		$activeLibrary = Library::getActiveLibrary();
 		$settings = new LibKeySetting();
@@ -13,16 +10,41 @@ class LibKeyDriver {
 			return null;
 		}
 		$curlWrapper = new CurlWrapper;
-		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $this->extractDoi($doiUrl) . "?access_token=" . $settings->apiKey);
+		$doi = $this->getDoi($data);
+		if (!$doi) {
+			return null;
+		}
+		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $doi . "?access_token=" . $settings->apiKey);
 		if (empty($response)) {
 			return null;
 		}
-		return json_decode($response, true)["data"]["bestIntegratorLink"]["bestLink"];
+		$result = json_decode($response, true)["data"]["bestIntegratorLink"]["bestLink"];
+		return $result;
 	}
-	public function extractDoi(string $url): string {
-		$doi = str_replace(["https://doi.org/", "http://"], "", $url);
-		return $doi;
+	
+	private function getDoi($data): string | null {
+		if (!is_object($data)) {
+			if (!$this->containsDoi($data)) {
+				return null;
+			}
+			return $this->extractDoiFromUrl($data);
+		}
+		return $this->findDoiInArray((array) $data);
 	}
+
+	private function findDoiInArray(array $uiList): string | null {
+		foreach ($uiList as $ui) {
+			if (!is_array($ui) && !is_object($ui) && $this->containsDoi($ui)) {
+				return $ui;
+			}
+		}
+		return null;
+	}
+
+	private function extractDoiFromUrl(string $url): string {
+		return str_replace(["https://doi.org/", "http://"], "", $url);
+	}
+
 	public function containsDoi(string $url): bool {
 		return preg_match('/10.\d{4,9}\/[-._;()\/:A-Za-z0-9]/', $url);
 	}

--- a/code/web/Drivers/LibKeyDriver.php
+++ b/code/web/Drivers/LibKeyDriver.php
@@ -1,7 +1,7 @@
 <?php
 
 class LibKeyDriver {
-	public function getLibKeyLink($data): string | null {
+	public function getLibKeyResult($data): array | null {
 		require_once ROOT_DIR . '/sys/LibKey/LibKeySetting.php';
 		$activeLibrary = Library::getActiveLibrary();
 		$settings = new LibKeySetting();
@@ -14,12 +14,11 @@ class LibKeyDriver {
 		if (!$doi) {
 			return null;
 		}
-		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $doi . "?access_token=" . $settings->apiKey);
+		$response = $curlWrapper->curlGetPage("https://public-api.thirdiron.com/public/v1/libraries/" . $settings->libraryId  . "/articles/doi/" . $doi . "?access_token=" . $settings->apiKey . "&include=journal");
 		if (empty($response)) {
 			return null;
 		}
-		$result = json_decode($response, true)["data"]["bestIntegratorLink"]["bestLink"];
-		return $result;
+		return json_decode($response, true);
 	}
 	
 	private function getDoi($data): string | null {

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -1414,7 +1414,7 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 	private function getLibKeyUrl($doiUrl) {
 		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
 		$libKeyDriver = new LibKeyDriver();
-		return $libKeyDriver->getLibKeyLink($doiUrl);
+		return $libKeyDriver->getLibKeyResult($doiUrl)["data"]["bestIntegratorLink"]["bestLink"];
 	}
 
 	private $catalogDriver = null;

--- a/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCO/result-tools-horizontal.tpl
@@ -3,6 +3,11 @@
 		<div class="result-tools-horizontal btn-toolbar" role="toolbar">
 			{* More Info Link, only if we are showing other data *}
 			{if !empty($showMoreInfo)}
+				{if $showMoreInfo !== false && !empty($libKeyUrl)}
+					<div class="btn-group btn-group-sm">
+						<a href="{$libKeyUrl}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text="Access Online" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Access Online" isPublicFacing=true}</a>
+					</div>
+				{/if}	
 				{if $showMoreInfo !== false}
 					<div class="btn-group btn-group-sm">
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
+++ b/code/web/interface/themes/responsive/EBSCOhost/result-tools-horizontal.tpl
@@ -3,6 +3,11 @@
 		<div class="result-tools-horizontal btn-toolbar" role="toolbar">
 			{* More Info Link, only if we are showing other data *}
 			{if !empty($showMoreInfo)}
+					{if $showMoreInfo !== false && !empty($libKeyUrl)}
+						<div class="btn-group btn-group-sm">
+							<a href="{$libKeyUrl}" class="btn btn-sm btn-tools" target="_blank" aria-label="{translate text="Access Online" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="Access Online" isPublicFacing=true}</a>
+						</div>
+					{/if}	
 				{if $showMoreInfo !== false}
 					<div class="btn-group btn-group-sm">
 						<a href="{if !empty($summUrl)}{$summUrl}{else}{$recordDriver->getLinkUrl()}{/if}" class="btn btn-sm btn-tools" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$recordDriver->getPermanentId()}')" target="_blank" aria-label="{translate text="More Info" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"><i class="fas fa-external-link-alt" role="presentation"></i> {translate text="More Info" isPublicFacing=true}</a>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
@@ -4,7 +4,11 @@
 		<div class="coversColumn col-xs-3 col-sm-3{if empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
-					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{if !empty($libKeyCoverImageUrl)}
+						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{else}
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{/if} 
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCO/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3{if empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
-					{if !empty($libKeyCoverImageUrl)}
+					{if !empty($libKeyCoverImageUrl) && !$retracted}
 						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{else}
 						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
@@ -23,6 +23,11 @@
 				</a>
 			</div>
 		</div>
+		{if $retracted}
+			<div class="alert alert-warning btn" id="retraction-warning" role="alert" aria-live="polite">
+				<strong><a href="{$libKeyUrl}" target="_blank"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" aria-label="{translate text="Retracted" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"></span> {translate text='Retracted' isPublicFacing=true}</a> <i class="fas fa-external-link-alt" role="presentation"></i></strong>
+			</div>
+		{/if}
 
 		{if !empty($summAuthor)}
 			<div class="row">

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
@@ -4,7 +4,11 @@
 		<div class="coversColumn col-xs-3 col-sm-3{if empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
-					<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{if !empty($libKeyCoverImageUrl)}
+						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{else}
+						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
+					{/if} 
 				</a>
 			{/if}
 		</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/EBSCOhost/result.tpl
@@ -4,7 +4,7 @@
 		<div class="coversColumn col-xs-3 col-sm-3{if empty($viewingCombinedResults)} col-md-3 col-lg-2{/if} text-center" aria-hidden="true" role="presentation">
 			{if $disableCoverArt != 1 && !empty($bookCoverUrlMedium)}
 				<a href="{$summUrl}" onclick="AspenDiscovery.EBSCO.trackEdsUsage('{$summId}')" target="_blank" aria-hidden="true">
-					{if !empty($libKeyCoverImageUrl)}
+					{if !empty($libKeyCoverImageUrl) && !$retracted}
 						<img src="{$libKeyCoverImageUrl}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
 					{else}
 						<img src="{$bookCoverUrlMedium}" class="listResultImage img-thumbnail {$coverStyle}" alt="{translate text='Cover Image' inAttribute=true isPublicFacing=true}">
@@ -23,6 +23,11 @@
 				</a>
 			</div>
 		</div>
+		{if $retracted}
+			<div class="alert alert-warning btn" id="retraction-warning" role="alert" aria-live="polite">
+				<strong><a href="{$libKeyUrl}" target="_blank"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true" aria-label="{translate text="Retracted" isPublicFacing=true inAttribute=true} ({translate text="opens in a new window" isPublicFacing=true inAttribute=true})"></span> {translate text='Retracted' isPublicFacing=true}</a> <i class="fas fa-external-link-alt" role="presentation"></i></strong>
+			</div>
+		{/if}
 
 		{if !empty($summAuthor)}
 			<div class="row">

--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -29,6 +29,15 @@
 //alexander
 
 //chloe
+### LibKey integration Updates
+
+For records found in an Articles and Database search through the EBSCO host or EBSCO EDS integration:
+- patrons of libraries with a LibKey subscription can access full-text document using an 'Access Online' button to the right of 'More Info' on search results. (*CZ*)
+- if the LibKey API does not return a direct link, then 'Access Online' does not show. (*CZ*)
+- for EBSCO EDS and host records, if the LibKey API sends back a cover image url, show this cover image on the search result. (*CZ*)
+- if the results from the LibKey API indicate an article has been retracted, they are marked as such. (*CZ*)
+- for retracted articles, a link to a LibKey page giving information on the retraction is displayed. (*CZ*)
+- for retracted articles, the 'Access Online' button is not displayed. (*CZ*)
 
 //pedro
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -2016,7 +2016,7 @@ class Record_AJAX extends Action {
 	private function getLibKeyUrl($doiUrl) {
 		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
 		$libKeyDriver = new LibKeyDriver();
-		return $libKeyDriver->getLibKeyLink($doiUrl);
+		return $libKeyDriver->getLibKeyResult($uniqueIdentifierList)["data"]["bestIntegratorLink"]["bestLink"];
 	}
 }
 

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -310,6 +310,14 @@ BODY;
 				$current = &$this->lastSearchResults->Data->Records[$x];
 				$interface->assign('recordIndex', $x + 1);
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
+				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers)) {
+					foreach ($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers as $ui) {
+						if ($ui->Type == "doi") {
+							$interface->assign('libKeyUrl', $this->getLibKeyUrl($ui->Value));
+							break;
+						}
+					}
+				}
 
 				require_once ROOT_DIR . '/RecordDrivers/EbscoRecordDriver.php';
 				$record = new EbscoRecordDriver($current);
@@ -907,4 +915,11 @@ BODY;
 
 		return $researchStarters;
 	}
+
+	private function getLibKeyUrl($uniqueIdentifierList) {
+		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
+		$libKeyDriver = new LibKeyDriver();
+		return $libKeyDriver->getLibKeyLink($uniqueIdentifierList);
+	}
+
 }

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -313,7 +313,9 @@ BODY;
 				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers)) {
 					foreach ($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers as $ui) {
 						if ($ui->Type == "doi") {
-							$interface->assign('libKeyUrl', $this->getLibKeyUrl($ui->Value));
+							$libKeyResult =  $this->getLibKeyResult($ui->Value);
+							$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
+							$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
 							break;
 						}
 					}
@@ -916,10 +918,10 @@ BODY;
 		return $researchStarters;
 	}
 
-	private function getLibKeyUrl($uniqueIdentifierList) {
+	private function getLibKeyResult($uniqueIdentifierList) {
 		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
 		$libKeyDriver = new LibKeyDriver();
-		return $libKeyDriver->getLibKeyLink($uniqueIdentifierList);
+		return $libKeyDriver->getLibKeyResult($uniqueIdentifierList);
 	}
 
 }

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -314,8 +314,14 @@ BODY;
 					foreach ($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers as $ui) {
 						if ($ui->Type == "doi") {
 							$libKeyResult =  $this->getLibKeyResult($ui->Value);
+							if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
+								$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
+								$interface->assign('retracted', true);
+								break;
+							}
 							$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
 							$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
+							$interface->assign('retracted', false);
 							break;
 						}
 					}

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -254,7 +254,9 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 				$current = &$this->lastSearchResults->SearchResults->records->rec[$x];
 				$interface->assign('recordIndex', $x + 1);
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
-
+				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($current->header->controlInfo->artinfo->ui)) {
+					$interface->assign('libKeyUrl', $this->getLibKeyUrl($current->header->controlInfo->artinfo->ui));
+				}
 				require_once ROOT_DIR . '/RecordDrivers/EbscohostRecordDriver.php';
 				$record = new EbscohostRecordDriver($current);
 				if ($record->isValid()) {
@@ -283,7 +285,7 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 		global $interface;
 		$html = [];
 		//global $logger;
-		//$logger->log(print_r($this->lastSearchResults, true), Logger::LOG_WARNING);
+		//$logger->log(print_r($this->lastSearchResults, true), Logger::LOG_ERROR);
 		if (isset($this->lastSearchResults->SearchResults->records)) {
 			for ($x = 0; $x < count($this->lastSearchResults->SearchResults->records->rec); $x++) {
 				$current = &$this->lastSearchResults->SearchResults->records->rec[$x];
@@ -814,14 +816,13 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 	function getBrowseRecordHTML() {
 		global $interface;
 		$html = [];
-		//global $logger;
-		//$logger->log(print_r($this->lastSearchResults, true), Logger::LOG_WARNING);
+		global $logger;
+
 		if (isset($this->lastSearchResults->SearchResults->records)) {
 			for ($x = 0; $x < count($this->lastSearchResults->SearchResults->records->rec); $x++) {
 				$current = &$this->lastSearchResults->SearchResults->records->rec[$x];
 				$interface->assign('recordIndex', $x + 1);
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
-
 				require_once ROOT_DIR . '/RecordDrivers/EbscohostRecordDriver.php';
 				$record = new EbscohostRecordDriver($current);
 				if ($record->isValid()) {
@@ -952,4 +953,11 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 		}
 		return $list;
 	}
+
+	private function getLibKeyUrl($uniqueIdentifierList) {
+		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
+		$libKeyDriver = new LibKeyDriver();
+		return $libKeyDriver->getLibKeyLink($uniqueIdentifierList);
+	}
+
 }

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -256,8 +256,15 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($current->header->controlInfo->artinfo->ui)) {
 					$libKeyResult =  $this->getLibKeyResult($current->header->controlInfo->artinfo->ui);
+					if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
+						$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
+						$interface->assign('retracted', true);
+						break;
+					}
 					$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
 					$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
+					$interface->assign('retracted', false);
+					break;
 				}
 				require_once ROOT_DIR . '/RecordDrivers/EbscohostRecordDriver.php';
 				$record = new EbscohostRecordDriver($current);

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -255,7 +255,9 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 				$interface->assign('recordIndex', $x + 1);
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($current->header->controlInfo->artinfo->ui)) {
-					$interface->assign('libKeyUrl', $this->getLibKeyUrl($current->header->controlInfo->artinfo->ui));
+					$libKeyResult =  $this->getLibKeyResult($current->header->controlInfo->artinfo->ui);
+					$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
+					$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
 				}
 				require_once ROOT_DIR . '/RecordDrivers/EbscohostRecordDriver.php';
 				$record = new EbscohostRecordDriver($current);
@@ -954,10 +956,9 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 		return $list;
 	}
 
-	private function getLibKeyUrl($uniqueIdentifierList) {
+	private function getLibKeyResult($uniqueIdentifier) {
 		require_once ROOT_DIR . "/Drivers/LibKeyDriver.php";
 		$libKeyDriver = new LibKeyDriver();
-		return $libKeyDriver->getLibKeyLink($uniqueIdentifierList);
+		return $libKeyDriver->getLibKeyResult($uniqueIdentifier);
 	}
-
 }


### PR DESCRIPTION
Jira ticket: [DIS-138](https://aspen-discovery.atlassian.net/browse/DIS-138)
---------------

Setting up LibKey before testing:

- navigate to Aspen Administration > Third Party
Enrichment > LibKey Settings
- create a new Setting (note: you will need
LibKey test credentials - can be requested from
ThirdIron)
- insert your credentials and add the library/ies
you plan to test the rest of the integration with
- save

For EBSCO host:
set up: see [https://drive.google.com/file/d/1PjoYk4pxaeuUxVLmHc3mFG9YEg1YG7g6/view](https://drive.google.com/file/d/1PjoYk4pxaeuUxVLmHc3mFG9YEg1YG7g6/view))

For EBSCO EDS
set up: see [https://aspen.bywatersolutions.com/education/setting-up-ebsco-eds](https://aspen.bywatersolutions.com/education/setting-up-ebsco-eds)

Test plan:

before applying the patch: 
- run a search in 'Article and Databases'
- take note of the covers images
- take note of the buttons available on each record

after applying the patch:
- notice the covers have now changed
- notice the new 'Access Online' link to the right of 'More Info' on each result
- check that the link opens the selected resource in a new tab (this should take you through LibKey and straight to the PDF document (if a pdf is available for the resource)
- find a retracted article, notice that a 'Retracted' warning message appears, that it is a link leading to LibKey page with information on the retraction, and that the 'Access Online' button is not available. 

 (if there are no retracted articles in your search results, you may want to temporarily set the doi in LibKeyDriver on line 13 to the doi of an article which you know is retracted, I used [10.1126/science.1124755](https://doi.org/10.1126/science.1124755). Note that this will apply to every single record in your search.)


