### PR TITLE
25.01.00 restore ebsco eds and host searcher

### DIFF
--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -144,6 +144,7 @@
 - Add an editorconfig file for template files to standardize using tabs across all files. (*MDN*)
 - Library card page (under 'My Account') no longer shows Koha user's opac notes if user's library 'Show OPAC Notes' is disabled.(*PA*)
 - Fix typo in Authentication/DatabaseAuthentication.php (DIS-159) (*LG*)
+- Fix EBSCO EDS and host searcher so that search results can be displayed and no error message shows. (*CZ*)
 
 ## This release includes code contributions from
 ### ByWater Solutions

--- a/code/web/sys/SearchObject/BaseSearcher.php
+++ b/code/web/sys/SearchObject/BaseSearcher.php
@@ -2356,7 +2356,7 @@ abstract class SearchObject_BaseSearcher {
 	 * @param bool $preventQueryModification Should we make sure the query doesn't change
 	 * @return  object   Search results (format may vary from class to class).
 	 */
-	abstract public function processSearch(bool $returnIndexErrors = false, bool $recommendations = false, bool $preventQueryModification = false) : AspenError|array|null;
+	abstract public function processSearch(bool $returnIndexErrors = false, bool $recommendations = false, bool $preventQueryModification = false) : AspenError|stdClass|SimpleXMLElement|array|null;
 
 	/**
 	 * Get error message from index response, if any.  This will only work if

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -569,7 +569,7 @@ BODY;
 		return false;
 	}
 
-	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|array|null {
+	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|stdClass|array|null {
 		$isAuthenticated = $this->authenticate();
 		if (empty($isAuthenticated)) {
 			return null;

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -632,7 +632,7 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 		return false;
 	}
 
-	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|array|null {
+	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|SimpleXMLElement|array|null {
 		$settings = $this->getSettings();
 		if ($settings == null) {
 			return new AspenError("EBSCOhost searching is not configured for this library.");


### PR DESCRIPTION
Jira ticket: https://aspen-discovery.atlassian.net/browse/DIS-221
___________

Bug:
When attempting to run a search in 'Articles and Databases' using the EBSCO EDS integration, the attempt to display the results fails, and the following error message is displayed instead:
SearchObject_EbscoEdsSearcher::processSearch(): Return value must be of type AspenError|array|null, stdClass returned

This also affect EBSCO host, where the following error is returned:
SearchObject_EbscohostSearcher::processSearch(): Return value must be of type AspenError|array|null, SimpleXMLElement returned.

We also checked:
- SummonSearcher (unaffected)
- GroupedWorkSearcher2 (unaffected)
- ListsSearcher (unaffected)


Searchers which could be affected and have not been checked yet are as follows:
- CourseResrversSearcher
- EventsSearcher
- GroupedWorkSearcher
- GenealogySearcher
- OpenArchivesSearcher
- WebsitesSearcher

*This list is based on the list of Searcher files where strict typing was added to the processSearch() method in [commit e024f04](https://github.com/Aspen-Discovery/aspen-discovery/commit/e024f0461ac56bebe29ec8fd1cf9f45112ea78c4)*

Cause:
In /aspen-discovery/code/web/sys/SearchObject/EbscoEdsSearcher.php, processSearch will return an instance of stdClass if successful.
However, since [commit e024f04](https://github.com/Aspen-Discovery/aspen-discovery/commit/e024f0461ac56bebe29ec8fd1cf9f45112ea78c4), the only return value  types allowed are AspenError and array. This was extended to include null  in [commit d137ae4](https://github.com/Aspen-Discovery/aspen-discovery/commit/d137ae473cd9146cad9bdf441b8daba88c7dccae), which did not resolve the issue.

Solution:
This patch adds stdClass to the list of valid return types, restoring functionality to the EBSCO EDS integration. 

Test plan in commit messages
