### PR TITLE
25.01.00 fix libkey for ebsco

### DIFF
--- a/code/web/release_notes/25.01.00.MD
+++ b/code/web/release_notes/25.01.00.MD
@@ -71,6 +71,8 @@
     - if the results from the LibKey API indicate an article has been retracted, they are marked as such. (*CZ*)
     - for retracted articles, a link to a LibKey page giving information on the retraction is displayed. (*CZ*)
     - for retracted articles, the 'Access Online' button is not displayed. (*CZ*)
+    - fixed an issue where the LibKey integration would prevent EBSCO host records from appearing due to a control flow issue. (*CZ*)
+    - fixed an issue where the LibKey integration would overwrite retraction notices for EBSCO EDS records. (*CZ*)
 
 ### Local ILL Updates
 - Properly handle volume level holds with Local ILL. (DIS-34) (*MDN*)

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -312,17 +312,20 @@ BODY;
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers)) {
 					foreach ($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers as $ui) {
-						if ($ui->Type == "doi") {
-							$libKeyResult =  $this->getLibKeyResult($ui->Value);
-							if ($libKeyResult && isset($libKeyResult['data'])) {
-								if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
-									$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
-									$interface->assign('retracted', true);
-								}
-								$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
-								$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
-								$interface->assign('retracted', false);
-							}
+						if ($ui->Type != "doi") {
+							continue;
+						}
+						$libKeyResult =  $this->getLibKeyResult($ui->Value);
+						if (!$libKeyResult || !isset($libKeyResult['data'])) {
+							continue;
+						}
+						if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
+							$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
+							$interface->assign('retracted', true);
+						} else {
+							$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
+							$interface->assign('retracted', false);
+							$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
 						}
 					}
 				}

--- a/code/web/sys/SearchObject/EbscoEdsSearcher.php
+++ b/code/web/sys/SearchObject/EbscoEdsSearcher.php
@@ -314,19 +314,18 @@ BODY;
 					foreach ($this->lastSearchResults->Data->Records[$x]->RecordInfo->BibRecord->BibEntity->Identifiers as $ui) {
 						if ($ui->Type == "doi") {
 							$libKeyResult =  $this->getLibKeyResult($ui->Value);
-							if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
-								$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
-								$interface->assign('retracted', true);
-								break;
+							if ($libKeyResult && isset($libKeyResult['data'])) {
+								if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
+									$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
+									$interface->assign('retracted', true);
+								}
+								$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
+								$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
+								$interface->assign('retracted', false);
 							}
-							$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
-							$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
-							$interface->assign('retracted', false);
-							break;
 						}
 					}
 				}
-
 				require_once ROOT_DIR . '/RecordDrivers/EbscoRecordDriver.php';
 				$record = new EbscoRecordDriver($current);
 				if ($record->isValid()) {

--- a/code/web/sys/SearchObject/EbscohostSearcher.php
+++ b/code/web/sys/SearchObject/EbscohostSearcher.php
@@ -256,15 +256,16 @@ class SearchObject_EbscohostSearcher extends SearchObject_BaseSearcher {
 				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
 				if (Library::getActiveLibrary()->libKeySettingId != -1 && !empty($current->header->controlInfo->artinfo->ui)) {
 					$libKeyResult =  $this->getLibKeyResult($current->header->controlInfo->artinfo->ui);
-					if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
-						$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
-						$interface->assign('retracted', true);
-						break;
+					if ($libKeyResult && isset($libKeyResult['data'])) {
+						if (isset($libKeyResult['data']['retractionNoticeUrl'])) {
+							$interface->assign('libKeyUrl', $libKeyResult['data']['retractionNoticeUrl']);
+							$interface->assign('retracted', true);
+						} else {
+							$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
+							$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
+							$interface->assign('retracted', false);
+						}
 					}
-					$interface->assign('libKeyUrl', $libKeyResult["data"]["bestIntegratorLink"]["bestLink"]);
-					$interface->assign('libKeyCoverImageUrl', $libKeyResult['included'][0]['coverImageUrl']);
-					$interface->assign('retracted', false);
-					break;
 				}
 				require_once ROOT_DIR . '/RecordDrivers/EbscohostRecordDriver.php';
 				$record = new EbscohostRecordDriver($current);


### PR DESCRIPTION
DEPENDENCY: https://github.com/Chloe070196/aspen-discovery/commit/a79125c4939428519b4e8e0b6b3480d4a412e0d0
___

When testing the 25.01.00 LibKey integration for EBSCO records, two issues were found. This patch addresses both:

## EBSCO host: the LibKey integration had the side effect of preventing EBSCO host records from displaying if  enabled.

- This is because the control flow would break out of the loop that generates the records when finding a LibKey link.
- This bug affected EBSCO host records.
- This patch amends this so that records are always displayed properly.

## EBSCO EDS: retraction notices warning messages and url were overwritten

- This patch ensures that, should a retraction notice link be sent back by LibKey for a given record, the retraction link is used to populate the relevant button, and the warning displayed to the user.
- Before this, the url would have been overwritten, and the 'retracted' variable set to true even if a retraction was found.
- For better readability, further amendments are made to the control flow with a switch from nested if statements to guard clauses.