### PR TITLE
Slim down cookie consent template

### DIFF
--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,37 +1,29 @@
 {if $loggedIn && $profile->userCookiePreferenceEssential == 1}
-	<script>
-		cookieValues = {
-			Essential: {$profile->userCookiePreferenceEssential},
-			Analytics: {$profile->userCookiePreferenceAnalytics},
-			UserLocalAnalytics: {$profile->userCookiePreferenceLocalAnalytics},
-		};
-		AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
-	</script>
-{elseif $loggedIn && (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))}
-	<div class="stripPopup">
-		<div class="cookieContainer">
-			<div class="contentWrap">
-				<span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
-				<abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
-			</div>
-			<div class="btnWrap">
-				<a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
-				<a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
-				<a onclick="AspenDiscovery.CookieConsent.cookieManage();" href="#" id="consentManage" class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
-			</div>
-		</div>
-	</div>
-{elseif !$loggedIn && (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConset, 'Essential'))}
-	<div class="stripPopup">
-		<div class="cookieContainer">
-			<div class="contentWrap">
-				<span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
-				<abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
-			</div>
-			<div class="btnWrap">
-				<a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
-				<a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
-			</div>
-		</div>
-	</div>
+    <script>
+        cookieValues = {
+            Essential: {$profile->userCookiePreferenceEssential},
+            Analytics: {$profile->userCookiePreferenceAnalytics},
+            UserLocalAnalytics: {$profile->userCookiePreferenceLocalAnalytics},
+        };
+        AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
+    </script>
+{elseif (empty($smarty.cookies.cookieConsent) || !strstr($smarty.cookies.cookieConsent,'Essential'))}
+    <div class="stripPopup">
+        <div class="cookieContainer">
+            <div class="contentWrap">
+                <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
+                <abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
+            </div>
+            <div class="btnWrap">
+                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree"
+                    class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
+                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree"
+                    class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
+                {if $loggedIn}
+                    <a onclick="AspenDiscovery.CookieConsent.cookieManage();" href="#" id="consentManage"
+                        class="button">{translate text="Manage Cookies" isPublicFacing=true}</a>
+                {/if}
+            </div>
+        </div>
+    </div>
 {/if}

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -105,6 +105,7 @@
 //kidclamp
 ### Other Updates
 - Use mb_substr to presrve diacritics in lists (DIS-178) (*WNC*)
+- Refactor Cookie consent tempate code (*JOM*)
 
 //yanjun
 
@@ -130,6 +131,7 @@
   - Alexander Blanchard (AB)
   - Chloe Zermatten (CZ)
   - Pedro Amorim (PA)
+  - Jacob O'Mara (JOM)
 
 ### Theke Solutions
   - Lucas Montoya (LM)


### PR DESCRIPTION
This patch refactors the cookie-consent.tpl to reduce the lines of code. The $loggedIn clause now only applies to the manage button of the banner. 

Test plan in main commit.