### PR TITLE
25.02.00 newsletter consent koha integration

### DIFF
--- a/code/web/CatalogConnection.php
+++ b/code/web/CatalogConnection.php
@@ -1923,4 +1923,8 @@ class CatalogConnection {
 			];
 		}
 	}
+
+	public function hasIlsConsentSupport(): bool {
+		return $this->driver->hasIlsConsentSupport();
+	}
 }

--- a/code/web/Drivers/AbstractIlsDriver.php
+++ b/code/web/Drivers/AbstractIlsDriver.php
@@ -917,4 +917,8 @@ abstract class AbstractIlsDriver extends AbstractDriver {
 			'message' => 'This functionality has not been implemented for this ILS',
 		];
 	}
+
+	public function hasIlsConsentSupport(): bool {
+		return false;
+	}
 }

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8585,4 +8585,8 @@ class Koha extends AbstractIlsDriver {
 			]);
 		}
 	}
+
+	public function hasIlsConsentSupport(): bool {
+		return true;
+	}
 }

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8502,7 +8502,7 @@ class Koha extends AbstractIlsDriver {
 		return $privacySection;
 	}
 
-	public function updatePatronConsent(int $patronIlsId, string $consentType, $consentEnabled = false) {
+	public function updatePatronConsent(int $patronIlsId, string $consentType, $consentEnabled = false): array {
 		$result = ['success' => false,];
 
 		$oauthToken = $this->getOAuthToken();
@@ -8551,7 +8551,7 @@ class Koha extends AbstractIlsDriver {
 		return $result;
 	}
 
-	public function getPatronConsents($patron) {	
+	public function getPatronConsents($patron): array {	
 		$oauthToken = $this->getOAuthToken();
 		if (!$oauthToken) {
 			$result['message'] = translate([
@@ -8594,7 +8594,7 @@ class Koha extends AbstractIlsDriver {
 
 	}
 
-	private function getConsentTypes() {
+	private function getConsentTypes(): array {
 		$oauthToken = $this->getOAuthToken();
 		if (!$oauthToken) {
 			return translate([

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8460,6 +8460,7 @@ class Koha extends AbstractIlsDriver {
 				'allCapsCode' => $key,
 				'label' => $consentType['title']['en'],
 				'description' => $consentType['description']['en'],
+				'actionConsentedTo' => $consentType['title']['en'] == 'Newsletter' ? "receiving our Newsletter" : $consentType['title']['en'],
 			];
 		}
 		return $formattedConsentTypes;

--- a/code/web/interface/themes/responsive/MyAccount/myPrivacySettings.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPrivacySettings.tpl
@@ -134,7 +134,7 @@
 								</div>
 							</div>
 							<div id="my{$consentCode}ConsentExplanation" style="display:none; margin-top: 10px;">
-									{translate text="By checking this box you are giving your consent to our {$consentType['label']}. Aspen Discovery will send your consent information to Koha, where it will be stored. You can return to this page to update your consent at any point."}
+									{translate text="By checking this box you are giving your consent to {$consentType['actionConsentedTo']}. You can return to this page to update your consent at any point."}
 							</div>
 						</section>
 					{/foreach}

--- a/code/web/interface/themes/responsive/MyAccount/myPrivacySettings.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPrivacySettings.tpl
@@ -119,6 +119,7 @@
 					<input type="hidden" name="patronId" value={$profile->id|escape}>
 					{foreach $consentTypes as $consentType}
 						<section id="{$consentType['lowercaseCode']}ConsentSection">
+						<input type="hidden" name="updateScopeSection" value="{$consentType['lowercaseCode']}">
 							{$consentCode = $consentType['capitalisedCode']}
 							<h2>{translate text={$consentType['label']} isPublicFacing=true}</h2>
 							<div class="form-group #propertyRow" style="margin-bottom:10px;">

--- a/code/web/release_notes/25.02.00.MD
+++ b/code/web/release_notes/25.02.00.MD
@@ -19,6 +19,8 @@
 
 - For libraries that use Koha as their ILS, and use the koha-plugin-newsletter-consent plugin
   - Administrator with the permission to edit library settings will be able to toggle on/off the 'Enable ILS-issued consents' setting under the 'Data Protection Regulations' section. (*CZ*)
+    - if the Koha plugin has not been installed and enabled in Koha, then the 'Enable ILS-issued consents' setting will not appear as it requires the plugin to be installed and enabled. (*CZ*)
+    - if the Koha plugin is uninstalled or disabled in Koha while 'Enable ILS-issued consents' is toggled on, 'Enable ILS-issued consents' will still display. (*CZ*)
   - If 'Enable ILS-issued consents' is enabled:
     - the 'Privacy Settings' options will appear in patron side menus. (*CZ*)
     - In the self-registration form, under a ‘Privacy’ section, patrons need to see information about the consent types set by their library in Koha. For example, they may be given the opportunity to receive the library’s newsletter. (*CZ*)
@@ -26,7 +28,7 @@
     - Patrons will be able to submit their consent along with their registration form. (*CZ*)
     - Patrons will be sent to Koha, where it is stored. (*CZ*)
     - Patrons will be able to view and change their consent information (as retrieved from Koha) at any point through the ‘Your Account > Privacy Settings ’ section. (*CZ*)
-
+    - If ILS consent is enabled in the Aspen settings, but the Koha plugin is disabled or uninstalled, patron will see an informative message in 'Privacy Settings'.  (*CZ*)
 //pedro
 
 // lucas

--- a/code/web/services/MyAccount/MyPrivacySettings.php
+++ b/code/web/services/MyAccount/MyPrivacySettings.php
@@ -3,7 +3,7 @@
 require_once ROOT_DIR . '/services/MyAccount/MyAccount.php';
 
 class MyAccount_MyPrivacySettings extends MyAccount {
-	function launch() {
+	function launch(): void {
 		global $interface;
 		global $library;
 

--- a/code/web/services/MyAccount/MyPrivacySettings.php
+++ b/code/web/services/MyAccount/MyPrivacySettings.php
@@ -9,19 +9,42 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 
 		if (!UserAccount::isLoggedIn()) {
 			$interface->assign('error', 'You must be logged in to access the Administration Interface');
-		} 
+		}
 		
-		// Do not lauch this page if there is nothing to show
+		// Handles patrons attempting to access the page directly through the URL when the 'Privacy Settings' link is disabled and does not show
 		if (!$library->ilsConsentEnabled && !$library->cookieStorageConsent) {
 			header("Location: " . '/MyAccount');
 		}
+		
+		$user = UserAccount::getLoggedInUser();
+		$linkedUsers = $user->getLinkedUsers();
+		$driver = $user->getCatalogDriver();
 
-		$interface->assign('ilsConsentEnabled', $library->ilsConsentEnabled);
+		$consentPluginNames = $driver->getPluginNamesByMethodName('patron_consent_type');
+		$anyConsentPluginsEnabled = false;
+
+		foreach($consentPluginNames as $pluginName) {
+			$pluginStatus = $driver->getPluginStatus($pluginName);
+			if ($library->ilsConsentEnabled && !$pluginStatus['enabled']) {
+				global $logger;
+				$statusDescription = $pluginStatus['installed'] ? 'disabled' : 'not installed';
+				$logger->log("Patrons Privacy Settings: Patrons cannot view and update their consents as the $pluginName plugin is $statusDescription", Logger::LOG_ERROR);
+	
+				$messages = [];
+				$messages[] = [
+					'message' => 'Other consent options are enabled but cannot be shown here due to a technical issue. Please contact your library.',
+					'messageStyle' => 'info',
+				];
+				$interface->assign('ilsMessages', $messages);
+				continue;
+			}
+			$anyConsentPluginsEnabled = true;
+		}
+
+		$interface->assign('ilsConsentEnabled', $library->ilsConsentEnabled && $anyConsentPluginsEnabled);
 		$interface->assign('cookieConsentEnabled', $library->cookieStorageConsent);
 		
 		//Determine which user we are showing/updating settings for
-		$user = UserAccount::getLoggedInUser();
-		$linkedUsers = $user->getLinkedUsers();
 		$patronId = isset($_REQUEST['patronId']) ? $_REQUEST['patronId'] : $user->id;
 		/** @var $patron */
 		$patronRefferedTo = $user->getUserReferredTo($patronId);
@@ -40,11 +63,10 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 		}
 
 		$action = $this->assignAction();
-		$driver = $user->getCatalogDriver();
-		$consentTypes = $library->ilsConsentEnabled ? $driver->getFormattedConsentTypes() : null;
+		$consentTypes = $library->ilsConsentEnabled && $anyConsentPluginsEnabled ? $driver->getFormattedConsentTypes() : null;
 
 		if ($action == 'save') {
-			$this->updatePrivacySettings($user, $patronRefferedTo, $driver, $library->ilsConsentEnabled, $consentTypes);
+			$this->updatePrivacySettings($user, $patronRefferedTo, $driver, $anyConsentPluginsEnabled, $consentTypes);
 			session_write_close();
 			$actionUrl = '/MyAccount/MyPrivacySettings' . ($patronRefferedTo->id == $user->id ? '': '?patronId=' . $patronId);
 			header("Location: " . $actionUrl);
@@ -60,7 +82,7 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 			$user->updateMessageIsError = 0;
 		}
 		
-		if (!$library->ilsConsentEnabled) {
+		if (!$library->ilsConsentEnabled || !$anyConsentPluginsEnabled) {
 			$this->display('myPrivacySettings.tpl', 'My Privacy Settings');
 			return;
 		}
@@ -93,7 +115,7 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 		return "";
 	}
 
-	private function updatePrivacySettings($user, $patronRefferedTo, $driver, $ilsConsentEnabled = null, $consentTypes = null): void {
+	private function updatePrivacySettings($user, $patronRefferedTo, $driver, $anyConsentPluginsEnabled = null, $consentTypes = null): void {
 		if ($_REQUEST['patronId'] != $user->id) {
 			$user->updateMessage = translate([
 				'text' => 'Wrong account credentials, please try again.',
@@ -111,10 +133,19 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 		}
 		
 		if ($_POST['updateScope'] === 'userILSIssuedConsent') {
-			if ($ilsConsentEnabled) {
-				foreach ($consentTypes as $consentType) {
-					$result = $driver->updatePatronConsent($patronRefferedTo->unique_ils_id, $consentType['allCapsCode'], isset($_POST['userNewsletter']));
-				}
+			$consentTypeName = $_REQUEST['updateScopeSection'];
+			if (!$anyConsentPluginsEnabled) {
+				global $logger;
+				$logger->log("Patrons Privacy Settings: Patron with id $patronRefferedTo->id could not update their $consentTypeName consent", Logger::LOG_ERROR);
+	
+				$user->updateMessage = translate([
+					'text' => 'Could not update consent due to a technical issue. Please contact your library',
+					'isPublicFacing' => true,
+				]);
+				$user->updateMessageIsError = true;
+			}
+			foreach ($consentTypes as $consentType) {
+				$result = $driver->updatePatronConsent($patronRefferedTo->unique_ils_id, $consentType['allCapsCode'], isset($_POST['userNewsletter']));
 			}
 		}
 		if (isset($result['message'])) {

--- a/code/web/sys/DBMaintenance/version_updates/25.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.02.00.php
@@ -24,6 +24,12 @@ function getUpdates25_02_00(): array {
 		//alexander - PTFS-Europe
 
 		//chloe - PTFS-Europe
+		'save_library_ils_consent_feature_toggle_value' => [
+			'title' => 'Save Library ILS Consent Feature Toggle Value',
+			'description' => 'Allows to record whether a library has enabled the ILS Consent feature or not',
+			'continueOnError' => false,
+			'sql' => ['ALTER TABLE library ADD COLUMN ilsConsentEnabled tinyint(1) DEFAULT 0'],
+		], //'save_library_ils_consent_feature_toggle_value'
 
 		//James Staub - Nashville Public Library
 

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -912,20 +912,6 @@ class Library extends DataObject {
 			$validCardRenewalOptions[3] = 'Quipu eRenewal';
 		}
 
-		// prevent administrators from enabling the ILS consent integration if their ILS does not allow for it
-		$driverAllowsForIlsConsentTypes = true;
-		if (
-			$catalog == null ||
-			$catalog->driver == null ||
-			!method_exists($catalog->driver, 'getConsentTypes') || 
-			!method_exists($catalog->driver, 'getFormattedConsentTypes') || 
-			!method_exists($catalog->driver, 'getPatronConsents') || 
-			!method_exists($catalog->driver, 'getSelfRegistrationFormPrivacySection') ||
-			!method_exists($catalog->driver, 'updatePatronConsent')
-		) {
-			$driverAllowsForIlsConsentTypes = false;
-		}
-
 		/** @noinspection HtmlRequiredAltAttribute */
 		/** @noinspection RequiredAttributes */
 		$structure = [
@@ -4183,7 +4169,7 @@ class Library extends DataObject {
 		if (!array_key_exists('Single sign-on', $enabledModules)) {
 			unset($structure['ssoSection']);
 		}
-		if (!$driverAllowsForIlsConsentTypes) {
+		if (!$catalog->hasIlsConsentSupport()) {
 			unset($structure['dataProtectionRegulations']['properties']['ilsConsentEnabled']);
 		}
 

--- a/install/aspen.sql
+++ b/install/aspen.sql
@@ -2779,7 +2779,6 @@ CREATE TABLE `library` (
   `eCommerceFee` varchar(11) DEFAULT '0',
   `eCommerceTerms` mediumtext DEFAULT NULL,
   `cookieStorageConsent` tinyint(1) DEFAULT 0,
-  `ilsConsentEnabled` tinyint(1) DEFAULT 0,
   `cookiePolicyHTML` text DEFAULT NULL,
   `openArchivesFacetSettingId` int(11) DEFAULT 1,
   `websiteIndexingFacetSettingId` int(11) DEFAULT 1,


### PR DESCRIPTION
Initial PR here: https://github.com/PTFS-Europe/aspen-discovery/pull/156
Current Aspen PR: https://github.com/Aspen-Discovery/aspen-discovery/pull/2198
______________________

Implement the following requested changes:

- actively checks whether any patron consent plugins are enabled in Koha, and handles the response accordingly
- refactor the checks on the driver objet to introduce a `hasIlsConsentSupport` method instead of using `method_exists`
- replace the database script change with a database update

Additionally, it updates the messages displayed to the patrons so they are clearer, and adds missing return types to methods created as part of DIS-98.