### PR TITLE
feat: add the ability to disable ils user creation when using sso

### DIFF
--- a/code/web/sys/Authentication/SAMLAuthentication.php
+++ b/code/web/sys/Authentication/SAMLAuthentication.php
@@ -205,17 +205,23 @@ class SAMLAuthentication{
 		$ssoArray = $this->mapSAMLAttributesToSSOArray($attributes);
 
 		if($this->ssoAuthOnly === false) {
-			$ilsUserArray = $this->setupILSUser($ssoArray);
-			if(!$this->validateWithILS($ssoArray)) {
-				if($this->selfRegister($ilsUserArray)) {
-					return $this->validateWithILS($ssoArray);
-				} else {
+			  $ilsUserArray = $this->setupILSUser($ssoArray);
+			  if(!$this->validateWithILS($ssoArray)) {
+				if ($this->config->createUserInIls) {
+					if($this->selfRegister($ilsUserArray)) {
+						return $this->validateWithILS($ssoArray);
+					} else {
 					AspenError::raiseError(new AspenError('Unable to register a new account with ILS during SAML authentication.'));
+					return false;
+					}
+				} else {
+					AspenError::raiseError(new AspenError('User does not exist in the ILS and autocreation of ILS users is disabled.'));
 					return false;
 				}
 			} else {
 				return $this->validateWithILS($ssoArray);
 			}
+			
 		} else {
 			if(!$this->validateWithAspen($this->uid)) {
 				$newUser = $this->selfRegisterAspenOnly($ssoArray);

--- a/code/web/sys/Authentication/SSOSetting.php
+++ b/code/web/sys/Authentication/SSOSetting.php
@@ -14,6 +14,7 @@ class SSOSetting extends DataObject {
     public $forceReAuth;
 	public $restrictByIP;
 	public $updateAccount;
+	public $createUserInIls;
 
 	//oAuth
 	public $clientId;
@@ -232,7 +233,15 @@ class SSOSetting extends DataObject {
 				'label' => 'Update users ILS account information with data from the IdP when logging in using the data mapping provided',
 				'description' => 'Whether or not users ILS account information is updated each time they log in using the data mapping provided',
 				'default' => 0,
-			],
+			  ],
+			  'createUserInIls' => [
+				'property' => 'createUserInIls',
+				'type' => 'checkbox',
+				'label' => 'Create ILS users when a matching user is not found from the IdP data in the ILS',
+				'description' => 'Whether or not to automatically create the ILS user if no match is found between IdP data and the ILS.',
+				'default' => 1,
+				'note' => 'If the user does not exist in the ILS when we sign in to Aspen with SSO, whether we can create that user in the ILS'
+			  ],
 			'oAuthConfigSection' => [
 				'property' => 'oAuthConfigSection',
 				'type' => 'section',

--- a/code/web/sys/DBMaintenance/version_updates/25.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.01.00.php
@@ -159,6 +159,18 @@ function getUpdates25_01_00(): array {
 		],	
 		//set_hoopla_index_by_day_to_default
 
+		//jacob - PTFS-Europe
+		'sso_do_not_create_user_in_ils' => [
+			'title' => 'Do not create SSO user in ils',
+			'description' => 'Ability to stop SSO from creating users in the ils',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE sso_setting ADD COLUMN createUserInIls int(11) DEFAULT 1',
+			]
+			
+		],
+		//sso_do_not_create_user_in_ils
+
 	];
 }
 


### PR DESCRIPTION
This patch adds the ability to disable the creation of users when using SSO for login

Test plan:
Set up SSO (for PTFS-> you can use the dev server settings)
In the SSO settings make sure that "Create ILS users when a matching user is not found from the IdP data in the ILS" is disabled
Try logging in with SSO, you should not be able to, should get error that makes sense
Turn on the above 
Try logging in again, it should work.
Disable it again
Logging in should still work as the user exists in the ILS now.
Feel free to try deleting the user in Koha to see that the login then does not work again if ils user creation is disabled.