### PR TITLE
DIS-98 fix: return true if any consent plugin enabled

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -8408,7 +8408,7 @@ class Koha extends AbstractIlsDriver {
 
 	public function areAnyConsentPluginsEnabled(): bool {
 		global $library;
-		$anyConsentPluginsEnabled = true;
+		$anyConsentPluginsEnabled = false;
 		$consentPluginNames = $this->getPluginNamesByMethodName('patron_consent_type');
 		foreach($consentPluginNames as $pluginName) {
 			$pluginStatus = $this->getPluginStatus($pluginName);
@@ -8416,9 +8416,9 @@ class Koha extends AbstractIlsDriver {
 				global $logger;
 				$statusDescription = $pluginStatus['installed'] ? 'disabled' : 'not installed';
 				$logger->log("Consent options could not be presented or recorded because the $pluginName plugin is $statusDescription", Logger::LOG_ERROR);
-				$anyConsentPluginsEnabled = false;
-				break;
-			} 
+				continue;
+			}
+			$anyConsentPluginsEnabled = true;
 		}
 		return $anyConsentPluginsEnabled;
 	}


### PR DESCRIPTION
Control flow logic fix (return true if as least one plugin is found and enabled, as opposed to returning true only if all are found and enabled) 

This would have affected functionality if more than one plugin is used and one or more plugins is not enabled. (Cannot fully test as there currently is only one patron consent plugin available for Koha)