### PR TITLE
DIS-219: Reverse Filter

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
@@ -37,13 +37,16 @@
 				<div id="linkedUsersDropdownContainer" class="form-group d-flex align-items-center mt-2 mt-md-0 ms-md-3">
 					<label for="linkedUsersDropdown" class="control-label me-2 mb-0">{translate text="Linked Users" isPublicFacing=true}&nbsp;</label>
 					<select id="linkedUsersDropdown" class="form-control me-2 mt-2 mt-md-0" name="linkedUserIds[]" multiple="multiple" size="2">
-						<option value="" {if empty($selectedUsers)}selected{/if}>None</option>
+						<option value="" {if empty($selectedUsers)}selected{/if}>All</option>
+						<option value="{$currentUserId}" {if in_array($currentUserId, $selectedUsers)} selected="selected"{/if}>
+							{$currentUserName}
+						</option>
 						{foreach from=$linkedUsers item=user}
 							<option value="{$user->id}"{if in_array($user->id, $selectedUsers)} selected="selected"{/if}>{$user->displayName}</option>
 						{/foreach}
 					</select>
 					<button type="button" class="btn btn-primary mt-2 mt-md-0" onclick="AspenDiscovery.Account.filterOutLinkedUsers();">
-						{translate text="Hide Users" isPublicFacing=true}
+						{translate text="Show Users" isPublicFacing=true}
 					</button>
 				</div>
 				{assign var="linkedUsersDropdownDisplayed" value=true}

--- a/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
@@ -1,4 +1,5 @@
 {assign var="hideCoversFormDisplayed" value=false}
+{assign var="linkedUsersDropdownDisplayed" value=false}
 {foreach from=$recordList item=sectionData key=sectionKey}
 	<h2>{if $sectionKey == 'available'}{translate text="Holds Ready For Pickup" isPublicFacing=true}{else}{if $source=='interlibrary_loan'}{translate text="Pending Requests" isPublicFacing=true}{else}{translate text="Pending Holds" isPublicFacing=true}{/if}{/if}</h2>
 	<p class="alert alert-info">
@@ -32,7 +33,7 @@
 				{/foreach}
 			</select>
 
-			{if count($linkedUsers) > 0}
+			{if count($linkedUsers) > 0 && empty($linkedUsersDropdownDisplayed)}
 				<div id="linkedUsersDropdownContainer" class="form-group d-flex align-items-center mt-2 mt-md-0 ms-md-3">
 					<label for="linkedUsersDropdown" class="control-label me-2 mb-0">{translate text="Linked Users" isPublicFacing=true}&nbsp;</label>
 					<select id="linkedUsersDropdown" class="form-control me-2 mt-2 mt-md-0" name="linkedUserIds[]" multiple="multiple" size="2">
@@ -45,6 +46,7 @@
 						{translate text="Hide Users" isPublicFacing=true}
 					</button>
 				</div>
+				{assign var="linkedUsersDropdownDisplayed" value=true}
 			{/if}
 
 			{if empty($hideCoversFormDisplayed)}

--- a/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/holdsList.tpl
@@ -1,5 +1,23 @@
 {assign var="hideCoversFormDisplayed" value=false}
-{assign var="linkedUsersDropdownDisplayed" value=false}
+
+{if count($linkedUsers) > 0 && empty($linkedUsersDropdownDisplayed)}
+	<div id="linkedUsersDropdownContainer" class="form-group mt-2 mt-md-0 ms-md-3">
+		<label for="linkedUsersDropdown" class="control-label me-2 mb-0">{translate text="Linked Users" isPublicFacing=true}&nbsp;</label>
+		<select id="linkedUsersDropdown" class="form-control" name="linkedUserIds[]" multiple="multiple" size="2">
+			<option value="" {if empty($selectedUsers)}selected{/if}>All</option>
+			<option value="{$currentUserId}" {if in_array($currentUserId, $selectedUsers)} selected="selected"{/if}>
+				{$currentUserName}
+			</option>
+			{foreach from=$linkedUsers item=user}
+				<option value="{$user->id}"{if in_array($user->id, $selectedUsers)} selected="selected"{/if}>{$user->displayName}</option>
+			{/foreach}
+		</select>
+		<button type="button" class="btn btn-primary" style="margin-top: 10px;" onclick="AspenDiscovery.Account.filterOutLinkedUsers();">
+			{translate text="Show Users" isPublicFacing=true}
+		</button>
+	</div>
+{/if}
+
 {foreach from=$recordList item=sectionData key=sectionKey}
 	<h2>{if $sectionKey == 'available'}{translate text="Holds Ready For Pickup" isPublicFacing=true}{else}{if $source=='interlibrary_loan'}{translate text="Pending Requests" isPublicFacing=true}{else}{translate text="Pending Holds" isPublicFacing=true}{/if}{/if}</h2>
 	<p class="alert alert-info">
@@ -33,24 +51,7 @@
 				{/foreach}
 			</select>
 
-			{if count($linkedUsers) > 0 && empty($linkedUsersDropdownDisplayed)}
-				<div id="linkedUsersDropdownContainer" class="form-group d-flex align-items-center mt-2 mt-md-0 ms-md-3">
-					<label for="linkedUsersDropdown" class="control-label me-2 mb-0">{translate text="Linked Users" isPublicFacing=true}&nbsp;</label>
-					<select id="linkedUsersDropdown" class="form-control me-2 mt-2 mt-md-0" name="linkedUserIds[]" multiple="multiple" size="2">
-						<option value="" {if empty($selectedUsers)}selected{/if}>All</option>
-						<option value="{$currentUserId}" {if in_array($currentUserId, $selectedUsers)} selected="selected"{/if}>
-							{$currentUserName}
-						</option>
-						{foreach from=$linkedUsers item=user}
-							<option value="{$user->id}"{if in_array($user->id, $selectedUsers)} selected="selected"{/if}>{$user->displayName}</option>
-						{/foreach}
-					</select>
-					<button type="button" class="btn btn-primary mt-2 mt-md-0" onclick="AspenDiscovery.Account.filterOutLinkedUsers();">
-						{translate text="Show Users" isPublicFacing=true}
-					</button>
-				</div>
-				{assign var="linkedUsersDropdownDisplayed" value=true}
-			{/if}
+			
 
 			{if empty($hideCoversFormDisplayed)}
 				{* Display the Hide Covers switch above the first section that has holds; and only display it once *}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3576,12 +3576,14 @@ class MyAccount_AJAX extends JSON_Action {
 			'unavailable' => [],
 		];
 
+		$allUsersSelected = in_array("", $selectedUsers);
+
 		foreach (['available', 'unavailable'] as $type) {
 			foreach ($allHolds[$type] as $key => $hold) {
-				$includeHold = true;
+				$includeHold = false;
 
-				if (!empty($selectedUsers)  && in_array($hold->userId, $selectedUsers)) {
-					$includeHold = false;
+				if ($allUsersSelected || empty($selectedUsers)  || in_array($hold->userId, $selectedUsers)) {
+					$includeHold = true;
 				}
 
 				if (!empty($selectedHolds)) {
@@ -3667,6 +3669,8 @@ class MyAccount_AJAX extends JSON_Action {
 
 				$selectedHolds = $this->setFilterSelectedHolds();
 				$interface->assign('selectedHolds', $selectedHolds);
+				$interface->assign('currentUserId', $user->id);
+				$interface->assign('currentUserName', $user->displayName);
 
 				$location = new Location();
 				$pickupBranches = $location->getPickupBranches($user);

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3578,35 +3578,43 @@ class MyAccount_AJAX extends JSON_Action {
 
 		$allUsersSelected = in_array("", $selectedUsers);
 
-		foreach (['available', 'unavailable'] as $type) {
-			foreach ($allHolds[$type] as $key => $hold) {
-				$includeHold = false;
+		foreach ($allHolds['available'] as $key => $hold) {
+			$includeHold = false;
 
-				if ($allUsersSelected || empty($selectedUsers)  || in_array($hold->userId, $selectedUsers)) {
-					$includeHold = true;
-				}
+			if ($allUsersSelected || empty($selectedUsers) || in_array($hold->userId, $selectedUsers)) {
+				$includeHold = true;
+			}
 
-				if (!empty($selectedHolds)) {
-					$matchFound = false;
-					foreach ($selectedHolds as $selectedHold) {
+			if ($includeHold) {
+				$filteredHolds['available'][$key] = $hold;
+			}
+		}
 
-						$holdRecordId = intval(trim($hold->recordId));
-						$selectedHoldRecordId = intval(trim($selectedHold['recordId']));
-						$holdUserId = intval(trim($hold->userId));
-						$selectedHoldUserId = intval(trim($selectedHold['userId']));
-						if ($holdRecordId == $selectedHoldRecordId && $holdUserId == $selectedHoldUserId){
-							$matchFound = true;
-							break;
-						}
+		foreach ($allHolds['unavailable'] as $key => $hold) {
+			$includeHold = false;
+
+			if ($allUsersSelected || empty($selectedUsers) || in_array($hold->userId, $selectedUsers)) {
+				$includeHold = true;
+			}
+			if (!empty($selectedHolds)) {
+				$matchFound = false;
+				foreach ($selectedHolds as $selectedHold) {
+					$holdRecordId = intval(trim($hold->recordId));
+					$selectedHoldRecordId = intval(trim($selectedHold['recordId']));
+					$holdUserId = intval(trim($hold->userId));
+					$selectedHoldUserId = intval(trim($selectedHold['userId']));
+					if ($holdRecordId == $selectedHoldRecordId && $holdUserId == $selectedHoldUserId){
+						$matchFound = true;
+						break;
 					}
-					if (!$matchFound) {
-						$includeHold = false;
-					}
 				}
+				if (!$matchFound) {
+					$includeHold = false;
+				}
+			}
 
-				if ($includeHold) {
-					$filteredHolds[$type][$key] = $hold;
-				}
+			if ($includeHold) {
+				$filteredHolds['unavailable'][$key] = $hold;
 			}
 		}
 		return $filteredHolds;
@@ -3737,6 +3745,9 @@ class MyAccount_AJAX extends JSON_Action {
 				if (!$offlineMode) {
 					if ($user) {
 						$allHolds = $this->filterHolds($user->getHolds(true, $selectedUnavailableSortOption, $selectedAvailableSortOption, $source), $selectedUsers, $selectedHolds);
+						error_log('Available Holds: ' . print_r($allHolds['available'], true));
+                    	error_log('Unavailable Holds: ' . print_r($allHolds['unavailable'], true));
+
 						$interface->assign('recordList', $allHolds);
 					}
 				}


### PR DESCRIPTION
Reverse the filtering of linked users so that linked users are filtered in rather than out of being displayed. 
Ensure that the filter only appears once, it will appear above the first section that had content - available holds or unavailable holds. 