### PR TITLE
fix: remove redundant and incorrect check

### DIFF
--- a/code/web/services/MyAccount/MyPrivacySettings.php
+++ b/code/web/services/MyAccount/MyPrivacySettings.php
@@ -6,10 +6,6 @@ class MyAccount_MyPrivacySettings extends MyAccount {
 	function launch(): void {
 		global $interface;
 		global $library;
-
-		if (!UserAccount::isLoggedIn()) {
-			$interface->assign('error', 'You must be logged in to access the Administration Interface');
-		}
 		
 		// Handles patrons attempting to access the page directly through the URL when the 'Privacy Settings' link is disabled and does not show
 		if (!$library->ilsConsentEnabled && !$library->cookieStorageConsent) {


### PR DESCRIPTION
Requested by Mark: since we are extending MyAccount, the 'is user logged in check' already runs upon the class being instantiated so that repeating it is unnecessary. Additionally, the error message included was incorrect.