### PR TITLE
25.01.01.ptfs bmj bp integration

### DIFF
--- a/code/web/Drivers/marmot_inc/SearchSources.php
+++ b/code/web/Drivers/marmot_inc/SearchSources.php
@@ -18,6 +18,9 @@ class SearchSources {
 			case 'summon':
 				$searchObject = SearchObjectFactory::initSearchObject('Summon');
 				break;
+			case 'bmjBp':
+				$searchObject = SearchObjectFactory::initSearchObject('BmjBp');
+				break;
 			case 'events':
 				$searchObject = SearchObjectFactory::initSearchObject('Events');
 				break;
@@ -92,6 +95,7 @@ class SearchSources {
 		$searchEbscoEDS = array_key_exists('EBSCO EDS', $enabledModules) && $library->edsSettingsId != -1;
 		$searchEbscohost = array_key_exists('EBSCOhost', $enabledModules) && $library->ebscohostSearchSettingId != -1;
 		$searchSummon = array_key_exists('Summon', $enabledModules) && $library->summonSettingsId != -1;
+		$searchBmjBp = array_key_exists('BMJ Best Practice', $enabledModules) && $library->bmjBpSettingId != -1;
 		$searchOpenArchives = array_key_exists('Open Archives', $enabledModules) && $library->enableOpenArchives == 1;
 		$searchCourseReserves = $library->enableCourseReserves == 2;
 
@@ -213,6 +217,16 @@ class SearchSources {
 				'hasAdvancedSearch' => false,
 			];
 		}
+
+		if ($searchBmjBp) {
+			$searchOptions['bmjBp'] = [
+				'name' => 'Articles & Databases',
+				'description' => 'BMJ Best Practice - Articles and Database',
+				'catalogType' => 'bmjBp ',
+				'hasAdvancedSearch' => false,
+			];
+		}
+		
 
 		// if ($searchSummon) {
 		// 	$searchOptions['summon'] = [

--- a/code/web/RecordDrivers/BmjBpRecordDriver.php
+++ b/code/web/RecordDrivers/BmjBpRecordDriver.php
@@ -1,0 +1,56 @@
+<?php
+require_once ROOT_DIR . '/RecordDrivers/RecordInterface.php';
+
+class BmjBpRecordDriver extends RecordInterface {
+	private $record;
+	/**
+	 * @param array|File_MARC_Record|string Record data to construct the driver from
+	 * @access  public
+	 */
+	public function __construct($record) {
+		$this->record = $record;
+	}
+
+	public function getBmjBpRecordId(): string {
+		if (!isset($this->record['id'])) {
+			return '';
+		}
+		return $this->record['id'];
+	}
+
+	public function getBmjBpRecordUrl(): string {
+		if (!isset($this->record['id'])) {
+			return '';
+		}
+		return "https://bestpractice.bmj.com/topics/en-gb/" . $this->record['id'];
+	}
+
+	public function getDescription(): string {
+		if(!isset($this->record['highlight'])) {
+			return '';
+		} 
+		return $this->record['highlight'];
+	}
+		}
+	public function getSearchResult($view = 'list', $showListsAppearingOn = true) {
+		global $interface;
+		$interface->assign('summId', $this->getBmjBpRecordId());
+		$interface->assign('summUrl', $this->getBmjBpRecordUrl());
+		$interface->assign('summTitle', $this->getTitle());
+		$interface->assign('summDescription', $this->getDescription());
+		return 'RecordDrivers/BmjBp/result.tpl';
+	}
+
+	public function getTitle(): string {
+		if (!isset($this->record['title'])) {
+			return '';
+		}
+		return $this->record['title'];;
+	}
+
+	/** required by RecordInterface, irrelevant to BMJ BP POC */
+	public function getBookcoverUrl($size='large', $absolutePath = false) {}
+	public function getStaffView() {} // only relevant if there is a detail view page
+	public function getMoreDetailsOptions() {}
+	public function getUniqueID() {} // irrelevant as it only pertains to Solr
+}

--- a/code/web/RecordDrivers/BmjBpRecordDriver.php
+++ b/code/web/RecordDrivers/BmjBpRecordDriver.php
@@ -25,13 +25,38 @@ class BmjBpRecordDriver extends RecordInterface {
 		return "https://bestpractice.bmj.com/topics/en-gb/" . $this->record['id'];
 	}
 
+	public function getCombinedResult(): string {
+		global $interface;
+		
+		$interface->assign('summId', $this->getBmjBpRecordId());
+		$interface->assign('module', $this->getModule());
+		$interface->assign('summFormats', $this->getFormats());
+		$interface->assign('summUrl', $this->getBmjBpRecordUrl());
+		$interface->assign('summTitle', $this->getTitle());
+		$interface->assign('summDescription', $this->getDescription());
+
+		return 'RecordDrivers/BmjBp/combinedResult.tpl';
+	}
+
 	public function getDescription(): string {
 		if(!isset($this->record['highlight'])) {
 			return '';
 		} 
 		return $this->record['highlight'];
 	}
+
+	public function getFormats(): string {
+		if(isset($this->record['ContentType'][0])){
+			return (string)$this->record['ContentType'][0];
 		}
+		$sourceType = 'Unknown Source';
+		return $sourceType;
+	}
+
+	public function getModule(): string {
+		return 'BmjBp';
+	}
+
 	public function getSearchResult($view = 'list', $showListsAppearingOn = true) {
 		global $interface;
 		$interface->assign('summId', $this->getBmjBpRecordId());

--- a/code/web/interface/themes/responsive/BmjBp/list.tpl
+++ b/code/web/interface/themes/responsive/BmjBp/list.tpl
@@ -1,0 +1,9 @@
+<h1 class="hiddenTitle">{translate text='Articles & Databases Search Results'}</h1>
+<div id="searchInfo">
+	{if !empty($subpage)}
+		{include file=$subpage}
+	{else}
+		{$pageContent}
+	{/if}
+	{if !empty($pageLinks.all)}<div class="text-center">{$pageLinks.all}</div>{/if}
+</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/BmjBp/combinedResult.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/BmjBp/combinedResult.tpl
@@ -1,0 +1,29 @@
+{strip}
+<div id="record{if !empty($summShortId)}{$summShortId}{else}{$summId|escape}{/if}" class="resultsList row">
+	<div class="col-xs-12">
+		<div class="row">
+			<div class="col-xs-12">
+				<span class="result-index">{$resultIndex})</span>&nbsp;
+				<a href="{$summUrl}" class="result-title notranslate" target="_blank">
+					{if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|truncate:180:"..."|highlight}{/if}
+				</a>
+			</div>
+		</div>
+		{if !empty($summDescription)}
+			{* Standard Description *}
+			<div class="row visible-xs">
+				<div class="result-label col-tn-3">{translate text='Description' isPublicFacing=true}</div>
+				<div class="result-value col-tn-8"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
+			</div>
+
+			{* Mobile Description *}
+			<div class="row">
+				{* Hide in mobile view *}
+				<div class="hidden-xs result-value col-sm-12" id="descriptionValue{$summId|escape}">
+					{$summDescription|highlight|truncate_html:450:"..."}
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>
+{/strip}

--- a/code/web/interface/themes/responsive/RecordDrivers/BmjBp/result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/BmjBp/result.tpl
@@ -1,0 +1,28 @@
+{strip}
+<div id="record{if !empty($summShortId)}{$summShortId}{else}{$summId|escape}{/if}" class="resultsList row">
+	<div class="col-tn-9 col-sm-9{if empty($viewingCombinedResults)} col-md-9 col-lg-10{/if}">
+		<div class="row">
+			<div class="col-xs-12">
+				<span class="result-index">{$resultIndex})</span>&nbsp;
+				<a href="{$summUrl}" class="result-title notranslate" onclick="AspenDiscovery.Summon.trackSummonUsage('{$summId}')" target="_blank">
+					{if !$summTitle|removeTrailingPunctuation} {translate text='Title not available' isPublicFacing=true}{else}{$summTitle|removeTrailingPunctuation|truncate:180:"..."|highlight}{/if}
+				</a>
+			</div>
+		</div>
+		{if !empty($summDescription)}
+			{* Standard Description *}
+			<div class="row visible-xs">
+				<div class="result-label col-tn-3">{translate text='Description' isPublicFacing=true}</div>
+				<div class="result-value col-tn-8"><a id="descriptionLink{$summId|escape}" href="#" onclick="$('#descriptionValue{$summId|escape},#descriptionLink{$summId|escape}').toggleClass('hidden-xs');return false;">{translate text="Click to view" isPublicFacing=true}</a></div>
+			</div>
+			{* Mobile Description *}
+			<div class="row">
+				{* Hide in mobile view *}
+				<div class="hidden-xs result-value col-sm-12" id="descriptionValue{$summId|escape}">
+					{$summDescription|highlight|truncate_html:450:"..."}
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>
+{/strip}

--- a/code/web/services/API/SystemAPI.php
+++ b/code/web/services/API/SystemAPI.php
@@ -407,11 +407,13 @@ class SystemAPI extends AbstractAPI {
 		$grapesWebBuilderUpdates = getGrapesWebBuilderUpdates();
 		require_once ROOT_DIR . '/sys/DBMaintenance/events_integration_updates.php';
 		$eventsIntegrationUpdates = getEventsIntegrationUpdates();
+		require_once ROOT_DIR . '/sys/DBMaintenance/bmj_bp_updates.php';
+		$bmjBpUpdates = getBmjBpUpdates();
 		require_once ROOT_DIR . '/sys/DBMaintenance/file_upload_updates.php';
 		$fileUploadUpdates = getFileUploadUpdates();
 		$finalBaseUpdates = getFinalBaseUpdates();
 
-		$baseUpdates = array_merge($initialUpdates, $library_location_updates, $postLibraryBaseUpdates, $user_updates, $grouped_work_updates, $genealogy_updates, $browse_updates, $collection_spotlight_updates, $indexing_updates, $overdrive_updates, $ebscoUpdates, $summonUpdates, $axis360Updates, $hoopla_updates, $rbdigital_updates, $sierra_api_updates, $theming_updates, $translation_updates, $open_archives_updates, $redwood_updates, $cloudLibraryUpdates, $websiteIndexingUpdates, $webBuilderUpdates, $grapesWebBuilderUpdates, $eventsIntegrationUpdates, $fileUploadUpdates, $finalBaseUpdates);
+		$baseUpdates = array_merge($initialUpdates, $library_location_updates, $postLibraryBaseUpdates, $user_updates, $grouped_work_updates, $genealogy_updates, $browse_updates, $collection_spotlight_updates, $indexing_updates, $overdrive_updates, $ebscoUpdates, $summonUpdates, $axis360Updates, $hoopla_updates, $rbdigital_updates, $sierra_api_updates, $theming_updates, $translation_updates, $open_archives_updates, $redwood_updates, $cloudLibraryUpdates, $websiteIndexingUpdates, $webBuilderUpdates, $grapesWebBuilderUpdates, $eventsIntegrationUpdates, $bmjBpUpdates, $fileUploadUpdates, $finalBaseUpdates);
 
 		//Get version updates
 		require_once ROOT_DIR . '/sys/Utils/StringUtils.php';

--- a/code/web/services/BmjBp/BmjBpSettings.php
+++ b/code/web/services/BmjBp/BmjBpSettings.php
@@ -1,0 +1,77 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+require_once ROOT_DIR . '/sys/BmjBp/BmjBpSetting.php';
+require_once ROOT_DIR . '/services/Admin/ObjectEditor.php';
+
+
+class BmjBpSettings extends ObjectEditor {	
+	function getObjectType(): string {
+		return 'BmjBpSetting';
+	}
+
+	function getToolName(): string {
+		return 'BmjBpSettings';
+	}
+
+	function getModule(): string {
+		return 'BmjBp';
+	}
+
+	function getPageTitle(): string {
+		return 'BMJ Best Practice Settings';
+	}
+
+	function getAllObjects($page, $recordsPerPage): array {
+		$object = new BmjBpSetting();
+		$object->limit(($page - 1) * $recordsPerPage, $recordsPerPage);
+		$this->applyFilters($object);
+		$object->orderBy($this->getSort());
+		$object->find();
+		$objectList = [];
+		while ($object->fetch()) {
+			$objectList[$object->id] = clone $object;
+		}
+		return $objectList;
+	}
+
+	function getDefaultSort(): string {
+		return 'name asc';
+	}
+
+	function getObjectStructure($context = ''): array {
+		return BmjBpSetting::getObjectStructure($context);
+	}
+
+	function getPrimaryKeyColumn(): string {
+		return 'id';
+	}
+
+	function getIdKeyColumn(): string {
+		return 'id';
+	}
+
+	function getAdditionalObjectActions($existingObject): array {
+		return [];
+	}
+
+	function getInstructions(): string {
+		return 'https://help.aspendiscovery.org/bmjbp';
+	}
+
+	function getBreadcrumbs(): array {
+		$breadcrumbs = [];
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home', 'Administration Home');
+		$breadcrumbs[] = new Breadcrumb('/Admin/Home#bmjbp', 'BmjBp');
+		$breadcrumbs[] = new Breadcrumb('/BmjBp/BmjBpSettings', 'Settings');
+		return $breadcrumbs;
+	}
+
+	function getActiveAdminSection(): string {
+		return 'bmjbp';
+	}
+
+	function canView(): bool {
+		return UserAccount::userHasPermission('View Dashboards');
+	}
+}

--- a/code/web/services/BmjBp/Results.php
+++ b/code/web/services/BmjBp/Results.php
@@ -8,14 +8,19 @@ class BmjBp_Results extends ResultsAction {
 		$searchObject = SearchObjectFactory::initSearchObject("BmjBp");
 		$searchObject->init();
 		$result = $searchObject->processSearch();
+		$displayQuery = $searchObject->displayQuery();
 		$recordSet = $searchObject->getResultRecordHTML();
 		$summary = $searchObject->getResultSummary();
-		$pageTitle = $searchObject->displayQuery();
 
+		if (strlen($displayQuery ) > 20) {
+			$displayQuery  = substr($displayQuery , 0, 20) . '...';
+		}
+
+		$interface->assign('lookfor', $displayQuery);
 		$interface->assign('recordSet', $recordSet);
 		$interface->assign('subpage', '../Search/list-list.tpl');
 		$interface->assign('sectionLabel', 'BMJ Best Practice');
-		$this->display($summary['resultTotal'] > 0 ? '../BmjBp/list.tpl' : '../Search/list-none.tpl', $pageTitle, false, false);
+		$this->display($summary['resultTotal'] > 0 ? '../BmjBp/list.tpl' : '../Search/list-none.tpl', $displayQuery , false, false);
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/BmjBp/Results.php
+++ b/code/web/services/BmjBp/Results.php
@@ -1,0 +1,16 @@
+<?php
+require_once ROOT_DIR . '/ResultsAction.php';
+class BmjBp_Results extends ResultsAction {
+	function launch() {
+		global $interface;
+
+		/** @var SearchObject_BmjBpSearcher $searchObject */
+		$searchObject = SearchObjectFactory::initSearchObject("BmjBp");
+		$searchObject->init();
+		$result = $searchObject->processSearch();
+	}
+
+	function getBreadcrumbs(): array {
+		return parent::getResultsBreadcrumbs('Articles & Databases');
+	}
+}

--- a/code/web/services/BmjBp/Results.php
+++ b/code/web/services/BmjBp/Results.php
@@ -15,12 +15,27 @@ class BmjBp_Results extends ResultsAction {
 		if (strlen($displayQuery ) > 20) {
 			$displayQuery  = substr($displayQuery , 0, 20) . '...';
 		}
+		if ($summary['resultTotal'] > 0) {
+			$this->implementPagination($searchObject, $summary);
+		}
 
 		$interface->assign('lookfor', $displayQuery);
 		$interface->assign('recordSet', $recordSet);
 		$interface->assign('subpage', '../Search/list-list.tpl');
 		$interface->assign('sectionLabel', 'BMJ Best Practice');
 		$this->display($summary['resultTotal'] > 0 ? '../BmjBp/list.tpl' : '../Search/list-none.tpl', $displayQuery , false, false);
+	}
+
+	function implementPagination($searchObject, $summary) {
+		global $interface;
+		$link = $searchObject->renderLinkPageTemplate();
+		$options = [
+			'totalItems' => $summary['resultTotal'],
+			'fileName' => $link,
+			'perPage' => $summary['perPage'],
+		];
+		$pager = new Pager($options);
+		$interface->assign('pageLinks', $pager->getLinks());
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/BmjBp/Results.php
+++ b/code/web/services/BmjBp/Results.php
@@ -8,6 +8,14 @@ class BmjBp_Results extends ResultsAction {
 		$searchObject = SearchObjectFactory::initSearchObject("BmjBp");
 		$searchObject->init();
 		$result = $searchObject->processSearch();
+		$recordSet = $searchObject->getResultRecordHTML();
+		$summary = $searchObject->getResultSummary();
+		$pageTitle = $searchObject->displayQuery();
+
+		$interface->assign('recordSet', $recordSet);
+		$interface->assign('subpage', '../Search/list-list.tpl');
+		$interface->assign('sectionLabel', 'BMJ Best Practice');
+		$this->display($summary['resultTotal'] > 0 ? '../BmjBp/list.tpl' : '../Search/list-none.tpl', $pageTitle, false, false);
 	}
 
 	function getBreadcrumbs(): array {

--- a/code/web/services/Union/AJAX.php
+++ b/code/web/services/Union/AJAX.php
@@ -42,6 +42,8 @@ class Union_AJAX extends JSON_Action {
 			$results = $this->getResultsFromEDS($searchTerm, $numberOfResults, $fullResultsLink);
 		} elseif ($source == 'summon') {
 			$results = $this->getResultsFromSummon($searchTerm, $numberOfResults, $fullResultsLink);
+		} elseif ($source == 'bmjBp') {
+			$results = $this->getResultsFromBmjBp($searchTerm, $numberOfResults, $fullResultsLink);
 		} elseif ($source == 'ebscohost') {
 			$results = $this->getResultsFromEbscohost($searchTerm, $numberOfResults, $fullResultsLink);
 		} elseif ($source == 'events') {
@@ -264,6 +266,49 @@ class Union_AJAX extends JSON_Action {
 		}
 		return $results;
 	}
+
+	/**
+	 * @param $searchTerm
+	 * @param $numberOfResults
+	 * @param $fullResultsLink
+	 * @return string a string of HTML to be used to display results from a BMJ Best Practice search in combined results
+	 */
+	private function getResultsFromBmjBp($searchTerm, $numberOfResults, $fullResultsLink): string {
+		global $interface;
+		$interface->assign('viewingCombinedResults', true);
+
+		if ($searchTerm == '') {
+			$results = '<div class="clearfix"></div><div>' . translate(['text'=>'Enter search terms to see results.', 'isPublicFacing'=>true]) . '</div>';
+			return $results;
+		} 
+
+		/** @var SearchObject_BmjBpSearcher $bmjBpSearcher */
+		$bmjBpSearcher = SearchObjectFactory::initSearchObject("BmjBp");
+		$bmjBpSearcher->init();
+		$bmjBpSearcher->setSearchTerms([
+			'index' =>$bmjBpSearcher->getDefaultIndex(),
+			'lookfor' => $searchTerm,
+		]);
+		$bmjBpSearcher->processSearch(true, false);
+
+		$summary = $bmjBpSearcher->getResultSummary();
+		if ($summary['resultTotal' == 0]) {
+			$results = '<div class="clearfix"></div><div>' . translate(['text'=>'No results match your search.', 'isPublicFacing'=>true]) . '</div>';
+			return $results;
+		}
+
+		$records = array_slice($bmjBpSearcher->getCombinedResultHTML(), 0, $numberOfResults);
+		
+		$interface->assign('recordSet', $records);
+		$interface->assign('showExploreMoreBar', false);
+		
+		$formattedNumResults = number_format($summary['resultTotal']);
+		$results = "<a href='{$fullResultsLink}' class='btn btn-default combined-results-button'>See all {$formattedNumResults} results <i class='fas fa-chevron-right fa-lg' role='presentation'></i></a><div class='clearfix'></div>";
+		$results .= $interface->fetch('Search/list-list.tpl');
+		return $results;
+	}
+
+
 
 	/**
 	 * @param $searchType

--- a/code/web/services/Union/Search.php
+++ b/code/web/services/Union/Search.php
@@ -105,6 +105,12 @@ class Union_Search extends ResultsAction {
 			$interface->assign('action', $action);
 			$this->searchResultsAction = new Summon_Results();
 			$this->searchResultsAction->launch();
+		} elseif ($searchSource == 'bmjBp') {
+			require_once(ROOT_DIR . '/services/BmjBp/Results.php');
+			$interface->assign('module', 'BmjBp');
+			$interface->assign('action','Results');
+			$this->searchResultsAction = new BmjBp_Results();
+			$this->searchResultsAction->launch();
 		} elseif ($searchSource == 'combined') {
 			require_once(ROOT_DIR . '/services/Union/CombinedResults.php');
 			$module = 'Union';

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -4363,6 +4363,11 @@ class User extends DataObject {
 			]);
 		}
 
+		if (array_key_exists('BMJ Best Practice', $enabledModules)) {
+			$sections['bmjbp'] = new AdminSection('BMJ Best Practice');
+			$sections['bmjbp']->addAction(new AdminAction('Settings', 'Define connection information between BMJ Best Practice and Aspen Discovery.', '/BmjBp/BmjBpSettings'), ['View Dashboards']);
+		}
+
 		if (array_key_exists('Hoopla', $enabledModules)) {
 			$sections['hoopla'] = new AdminSection('Hoopla');
 			$hooplaSettingsAction = new AdminAction('Settings', 'Define connection information between Hoopla and Aspen Discovery.', '/Hoopla/Settings');

--- a/code/web/sys/BmjBp/BmjBpSetting.php
+++ b/code/web/sys/BmjBp/BmjBpSetting.php
@@ -1,0 +1,135 @@
+<?php
+
+class BmjBpSetting extends DataObject {
+	public $__table = 'bmj_bp_settings';
+	public $id;
+	public $name;
+	public $bmjBpBaseApiUrl;
+	public $bmjBpApiKey;
+	public $bmjBpApiSecret;
+
+	private $_libraries;
+
+	function getEncryptedFieldNames(): array {
+		return ['bmjBpApiKey', 'bmjBpApiSecret'];
+	}
+
+	public static function getObjectStructure($context = ''): array {
+		$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer All Libraries'));
+
+		return [
+			'id' => [
+				'property' => 'id',
+				'type' => 'label',
+				'label' => 'Id',
+				'description' => 'The unique id',
+			],
+			'name' => [
+				'property' => 'name',
+				'type' => 'text',
+				'label' => 'Name',
+				'maxLength' => 50,
+				'description' => 'A name for these settings',
+				'required' => true,
+			],
+			'bmjBpBaseApiUrl' => [
+				'property' => 'bmjBpBaseApiUrl',
+				'type' => 'text',
+				'label' => 'BMJ Best Practice Base API URL',
+				'description' => 'The url to use when connecting to BMJ Best Practice API',
+				'hideInLists' => true,
+			],
+			'bmjBpApiKey' => [
+				'property' => 'bmjBpApiKey',
+				'type' => 'storedPassword',
+				'label' => 'BMJ Best Practice API Key',
+				'description' => 'The key to use when connecting to the BMJ Best Practice API',
+				'hideInLists' => true,
+			],
+			'bmjBpApiSecret' => [
+				'property' => 'bmjBpApiSecret',
+				'type' => 'storedPassword',
+				'label' => 'BMJ Best Practice API Secret',
+				'description' => 'The secret to use when connecting to the BMJ Best Practice API',
+				'hideInLists' => true,
+			],
+			'libraries' => [
+				'property' => 'libraries',
+				'type' => 'multiSelect',
+				'listStyle' => 'checkboxSimple',
+				'label' => 'Libraries',
+				'description' => 'Define libraries that use this setting',
+				'values' => $libraryList,
+				'hideInLists' => true,
+			],
+		];
+	}
+
+	public function __get($name) {
+		if ($name == "libraries") {
+			if (!isset($this->_libraries) && $this->id) {
+				$this->_libraries = [];
+				$obj = new Library();
+				$obj->bmjBpSettingId = $this->id;
+				$obj->find();
+				while ($obj->fetch()) {
+					$this->_libraries[$obj->libraryId] = $obj->libraryId;
+				}
+			}
+			return $this->_libraries;
+		} else {
+			return parent::__get($name);
+		}
+	}
+
+	public function __set($name, $value) {
+		if ($name == "libraries") {
+			$this->_libraries = $value;
+		} else {
+			parent::__set($name, $value);
+		}
+	}
+
+	public function update($context = '') {
+		$ret = parent::update();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return true;
+	}
+
+	public function insert($context = '') {
+		$ret = parent::insert();
+		if ($ret !== FALSE) {
+			$this->saveLibraries();
+		}
+		return $ret;
+	}
+
+	public function saveLibraries() {
+		if (isset ($this->_libraries) && is_array($this->_libraries)) {
+			$libraryList = Library::getLibraryList(!UserAccount::userHasPermission('Administer All Libraries'));
+			foreach ($libraryList as $libraryId => $displayName) {
+				$library = new Library();
+				$library->libraryId = $libraryId;
+				$library->find(true);
+				if (in_array($libraryId, $this->_libraries)) {
+					if ($library->bmjBpSettingId != $this->id) {
+						$library->finePaymentType = 2;
+						$library->bmjBpSettingId = $this->id;
+						$library->update();
+					}
+				} else {
+					if ($library->bmjBpSettingId == $this->id) {
+						if ($library->finePaymentType == 2) {
+							$library->finePaymentType = 0;
+						}
+						$library->bmjBpSettingId = -1;
+						$library->update();
+					}
+				}
+			}
+			unset($this->_libraries);
+		}
+	}
+}

--- a/code/web/sys/DBMaintenance/bmj_bp_updates.php
+++ b/code/web/sys/DBMaintenance/bmj_bp_updates.php
@@ -1,0 +1,28 @@
+<?php
+/** @noinspection SqlResolve */
+function getBmjBpUpdates() {
+	return [
+		'create_bmj_bp_module' => [
+			'title' => 'Create BMJ Best Practice module',
+			'description' => 'Setup modules for BMJ Best Practice Integration',
+			'sql' => [
+				"INSERT INTO modules (name, indexName, backgroundProcess) VALUES ('BMJ Best Practice', '', '')",
+
+			],
+		],
+		'create_settings_for_bmj_bp' => [
+			'title' => 'Create BMJ Best Practice settings',
+			'description' => 'Create settings to store information for BMJ Best Practice Integrations',
+			'continueOnError' => true,
+			'sql' => [
+				"CREATE TABLE bmj_bp_settings (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+					name VARCHAR(250) NOT NULL,
+					bmjBpBaseApiUrl VARCHAR(250) DEFAULT '',
+					bmjBpApiKey VARCHAR(250) DEFAULT '',
+					bmjBpApiSecret VARCHAR(250) DEFAULT ''
+				)",
+				'ALTER TABLE library ADD COLUMN bmjBpSettingId INT(11) DEFAULT -1',
+			],
+		],
+	];
+}

--- a/code/web/sys/LibraryLocation/CombinedResultSection.php
+++ b/code/web/sys/LibraryLocation/CombinedResultSection.php
@@ -26,6 +26,9 @@ abstract class CombinedResultSection extends DataObject {
 		if (array_key_exists('Summon', $enabledModules) && $library->summonSettingsId != -1) {
 			$validResultSources['summon'] = 'Summon';
 		}
+		if (array_key_exists('BMJ Best Practice', $enabledModules) && $library->bmjBpSettingsId != -1) {
+			$validResultSources['bmjBp'] = 'BmjBp';
+		}
 		if (array_key_exists('Events', $enabledModules)) {
 			$validResultSources['events'] = 'Events';
 		}
@@ -95,6 +98,8 @@ abstract class CombinedResultSection extends DataObject {
 			return "https://dp.la/search?q=$searchTerm";
 		} elseif ($this->source == 'summon') {
 			return "Search/Results?lookfor=$searchTerm&searchSource=summon";
+		} elseif ($this->source == 'bmjBp') {
+			return "/Union/Search?view=list&lookfor=$searchTerm&searchIndex=Keyword&searchSource=bmjBp";
 		} elseif ($this->source == 'ebsco_eds') {
 			return "/EBSCO/Results?lookfor=$searchTerm&searchSource=ebsco_eds";
 		} elseif ($this->source == 'ebscohost') {

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -386,6 +386,9 @@ class Library extends DataObject {
 	public $summonSettingsId;
 	public $showAvailableCoversInSummon;
 
+	//BMJ BP Settings
+	public $bmjBpSettingId;
+
 	//Combined Results (Bento Box)
 	public /** @noinspection PhpUnused */
 		$enableCombinedResults;
@@ -802,6 +805,15 @@ class Library extends DataObject {
 			$summonSettings[$summonSetting->id] = $summonSetting->name;
 		}
 
+		require_once ROOT_DIR . '/sys/BmjBp/BmjBpSetting.php';
+		$bmjBpSetting = new BmjBpSetting();
+		$bmjBpSetting->orderBy('name');
+		$bmjBpSettings = [];
+		$bmjBpSetting->find();
+		$bmjBpSettings[-1] = 'none';
+		while ($bmjBpSetting->fetch()) {
+			$bmjBpSettings[$bmjBpSetting->id] = $bmjBpSetting->name;
+		}
 
 		require_once ROOT_DIR . '/sys/Ebsco/EBSCOhostSetting.php';
 		$ebscohostSetting = new EBSCOhostSearchSetting();
@@ -3887,6 +3899,25 @@ class Library extends DataObject {
 					],
 				],
 			],
+			
+			'bmjBpSection' => [
+				'property' => 'bmjBpSection',
+				'type' => 'section',
+				'label' => 'BMJ Best Practice',
+				'hideInLists' => true,
+				'renderAsHeading' => true,
+				'properties' => [
+					'bmjBpSettingId' => [
+						'property' => 'bmjBpSettingId',
+						'type' => 'enum',
+						'values' => $bmjBpSettings,
+						'label' => 'BMJ Best Practice Settings',
+						'description' => 'Whether or not searching for BMJ Best Practice metadata should be enabled for this library.',
+						'hideInLists' => true,
+						'default' => -1,
+					],
+				],
+			],
 
 
 			'casSection' => [
@@ -4134,6 +4165,9 @@ class Library extends DataObject {
 		}
 		if (!array_key_exists('Summon', $enabledModules)) {
 			unset($structure['summonSection']);
+		}
+		if (!array_key_exists('BMJ Best Practice', $enabledModules)) {
+			unset($structure['bmjBpSection']);
 		}
 		if (!array_key_exists('Genealogy', $enabledModules)) {
 			unset($structure['genealogySection']);

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -28,6 +28,8 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 	/** @var int */
 	protected $limit = 10; // or use limit?
 
+	private $curl_connection;
+
 	private $searchIndex = '';
 
 	public function __construct() {
@@ -49,6 +51,20 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		}
 
 		return true;
+	}
+
+	public function getCurlConnection(): object {
+		if ($this->curl_connection == null) {
+			$this->curl_connection = curl_init();
+			curl_setopt($this->curl_connection, CURLOPT_CONNECTTIMEOUT, 15);
+			curl_setopt($this->curl_connection, CURLOPT_USERAGENT, "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)");
+			curl_setopt($this->curl_connection, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($this->curl_connection, CURLOPT_SSL_VERIFYPEER, false);
+			curl_setopt($this->curl_connection, CURLOPT_FOLLOWLOCATION, 1);
+			curl_setopt($this->curl_connection, CURLOPT_TIMEOUT, 30);
+			curl_setopt($this->curl_connection, CURLOPT_RETURNTRANSFER, TRUE);
+		}
+		return $this->curl_connection;
 	}
 
 	public function getJwt(): string {
@@ -151,6 +167,27 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		];
 	}
 
+	protected function sendHttpRequest($baseUrl, $queryString, $headers): array {
+		foreach ($headers as $key =>$value) {
+			$modified_headers[] = $key.": ".$value;
+		}
+		$curlConnection = $this->getCurlConnection();
+		$curlOptions = array(
+			CURLOPT_RETURNTRANSFER => 1,
+			CURLOPT_URL => "{$baseUrl}?{$queryString}",
+			CURLOPT_HTTPHEADER => $modified_headers
+		);
+
+		curl_setopt_array($curlConnection, $curlOptions);
+		$result = curl_exec($curlConnection);
+		$responseCode = curl_getinfo($curlConnection, CURLINFO_RESPONSE_CODE);
+		if ($result === false || $responseCode != '200') {
+			AspenError::raiseError("Could not get results from BMJ Best practice: error in HTTP Request.");
+		}
+		curl_close($curlConnection);
+		return json_decode($result, true);
+	}
+	
 	function getSearchName(): string {
 		return $this->searchSource;
 	}
@@ -164,6 +201,7 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		$baseApiUrl = $this->getSettings()->bmjBpBaseApiUrl;
 		$queryString = $this->buildQueryString();
 		$headers = $this->getHeaders();
+		$responseData= $this->sendHttpRequest($baseApiUrl, $queryString, $headers)['monograph'];
 	}
 
 	public function __destruct() {

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -19,6 +19,9 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 	/** @var int */
 	protected $limit = 10; // or use limit?
 
+	/** @var BmjBpSetting */
+	private $settings;
+
 	private $searchIndex = '';
 
 	public function __construct() {
@@ -40,6 +43,27 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		}
 
 		return true;
+	}
+
+	public function getSettings(): BmjBpSetting {
+		if (empty($this->settings)) {
+			$this->setSettings();
+		}
+		return $this->settings;
+	}
+
+	public function setSettings(): void {
+		global $library;
+		if ($library->bmjBpSettingId == -1) {
+			AspenError::raiseError(new AspenError('There are no BmjBp Settings set for this library system.'));
+			return;
+		}
+		$settings = new BmjBpSetting();
+		$settings->id = $library->bmjBpSettingId;
+		if (!$settings->find(true)) {
+			$settings = null;
+		}
+		$this->settings = $settings;
 	}
 
 	private function getSearchOptions (): array{
@@ -93,6 +117,7 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 
 	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|array|null {
 		// TODO: determine which guard clauses are needed here
+		$baseApiUrl = $this->getSettings()->bmjBpBaseApiUrl;
 		$queryString = $this->buildQueryString();
 	}
 

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -30,6 +30,8 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 
 	private $curl_connection;
 
+	protected $lastSearchResults;
+
 	private $searchIndex = '';
 
 	public function __construct() {
@@ -143,6 +145,26 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		];
 	}
 
+	public function getResultRecordHTML(): array {
+		global $interface;
+		global $timer;
+		$html = [];
+		$timer->logTime("Starting to load record html");
+		if (isset($this->lastSearchResults)) {
+			for ($x = 0; $x < count($this->lastSearchResults); $x++) {
+				$current = &$this->lastSearchResults[$x];
+				$interface->assign('recordIndex', $x + 1);
+				$interface->assign('resultIndex', $x + 1 + (($this->page - 1) * $this->limit));
+
+				require_once ROOT_DIR . '/RecordDrivers/BmjBpRecordDriver.php';
+				$record = new BmjBpRecordDriver($current);
+				$interface->assign('recordDriver', $record);
+				$html[] = $interface->fetch($record->getSearchResult());
+			}
+		};
+		return $html;
+	}
+
 	function buildQueryString(): string {
 		$query = "";
 		$index = 0;
@@ -202,6 +224,9 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		$queryString = $this->buildQueryString();
 		$headers = $this->getHeaders();
 		$responseData= $this->sendHttpRequest($baseApiUrl, $queryString, $headers)['monograph'];
+		$this->resultsTotal = $responseData['total'];
+		$this->lastSearchResults = $responseData['results'];
+		return $responseData;
 	}
 
 	public function __destruct() {

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -5,7 +5,16 @@ require_once ROOT_DIR . '/sys/Pager.php';
 require_once ROOT_DIR . '/sys/SearchObject/BaseSearcher.php';
 
 class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
+	// TODO: use the CurlWrapper class instead of vanilla PHP CURL?
+	// TODO: implement a JWT library
 
+	static $instance;
+	/** @var string */
+	private $jwt;
+	/** @var BmjBpSetting */
+	private $settings;
+	/** @var array */
+	private $headers;
 	/** @var array */
 	private $searchOptions;
 
@@ -18,12 +27,6 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 	protected $page = 1; // or use page?
 	/** @var int */
 	protected $limit = 10; // or use limit?
-
-	/** @var string */
-	private $jwt;
-
-	/** @var BmjBpSetting */
-	private $settings;
 
 	private $searchIndex = '';
 
@@ -93,6 +96,20 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		$this->settings = $settings;
 	}
 
+	public function getHeaders(): array {
+		if (empty($headers)) {
+			$this->setHeaders($this->getJwt());
+		}
+		return $this->headers;
+	}
+
+	public function setHeaders(): void {
+		$this->headers = array(
+			'Accept' => 'application/json',
+			'Authorization' => 'JWT Bearer ' . $this->getJwt(),
+		);
+	}
+
 	private function getSearchOptions (): array{
 		if (empty($searchOptions)) {
 			$this->setSearchOptions();
@@ -146,6 +163,7 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		// TODO: determine which guard clauses are needed here
 		$baseApiUrl = $this->getSettings()->bmjBpBaseApiUrl;
 		$queryString = $this->buildQueryString();
+		$headers = $this->getHeaders();
 	}
 
 	public function __destruct() {

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -165,6 +165,25 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		return $html;
 	}
 
+	public function getCombinedResultHTML(): array {
+		global $interface;
+		$html = [];
+		if (isset($this->lastSearchResults)) {
+			foreach($this->lastSearchResults as $key=>$value){
+				$interface->assign('recordIndex', $key + 1);
+				$interface->assign('resultIndex', $key + 1 + (($this->page - 1) * $this->limit));
+
+				require_once ROOT_DIR . '/RecordDrivers/BmjBpRecordDriver.php';
+				$record = new BmjBpRecordDriver($value);
+				$interface->assign('recordDriver', $record);
+				$html[] = $interface->fetch($record->getCombinedResult());
+			}
+		} else {
+			$html[] = "Unable to find record";
+		}
+		return $html;
+	}
+
 	function buildQueryString(): string {
 		$query = "";
 		$index = 0;
@@ -216,6 +235,10 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 
 	public function getEngineName(): string {
 		return 'bmjBp';
+	}
+
+	public function getDefaultIndex(): string {
+		return $this->searchIndex;
 	}
 
 	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|array|null {

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -1,0 +1,113 @@
+<?php
+
+require_once ROOT_DIR . '/sys/BmjBp/BmjBpSetting.php';
+require_once ROOT_DIR . '/sys/Pager.php';
+require_once ROOT_DIR . '/sys/SearchObject/BaseSearcher.php';
+
+class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
+
+	/** @var array */
+	private $searchOptions;
+
+	/** Values for the searchOptions array*/
+	/** @var string */
+	protected $language = 'en-gb'; // 'en' is not supported
+	/** @var string */
+	protected $type = 'MONOGRAPH';
+	/** @var int */
+	protected $page = 1; // or use page?
+	/** @var int */
+	protected $limit = 10; // or use limit?
+
+	private $searchIndex = '';
+
+	public function __construct() {
+		$this->searchSource = 'bmjBp';
+		$this->searchType = 'bmjBp';
+		$this->resultsModule = 'BmjBp';
+		$this->resultsAction = 'Results';
+	}
+
+	public function init($searchSource = null): bool {
+		$this->initView();
+		$this->initPage();
+		$this->initSort();
+		$this->initFilters();
+		$this->initLimiters();
+
+		if (!$this->initBasicSearch()) {
+			$this->initAdvancedSearch();
+		}
+
+		return true;
+	}
+
+	private function getSearchOptions (): array{
+		if (empty($searchOptions)) {
+			$this->setSearchOptions();
+		}
+		return $this->searchOptions;
+	}
+
+	private function setSearchOptions (): void {
+		$this->searchOptions = [
+			'searchTerm'=> $this->searchTerms[0]['lookfor'],
+			'language' => $this->language,
+			'type' => $this->type,
+			'from' => $this->page - 1,
+			'size' => $this->limit,
+		];
+	}
+
+	function buildQueryString(): string {
+		$query = "";
+		$index = 0;
+		foreach ($this->getSearchOptions() as $key => $value) {
+			if ($index > 0) {
+				$query .= '&';
+			}
+			$value = urlencode($value);
+			$query .= "$key=$value";
+			$index ++;
+		}
+		return $query;
+	}
+	
+	public function getSearchIndexes(): array {
+		return [
+			'Keyword' => translate([
+				'text' => "Keyword",
+				'isPublicFacing' => true,
+				'inAttribute' => true,
+			])
+		];
+	}
+
+	function getSearchName(): string {
+		return $this->searchSource;
+	}
+
+	public function getEngineName(): string {
+		return 'bmjBp';
+	}
+
+	public function processSearch($returnIndexErrors = false, $recommendations = false, $preventQueryModification = false) : AspenError|array|null {
+		// TODO: determine which guard clauses are needed here
+		$queryString = $this->buildQueryString();
+	}
+
+	public function __destruct() {
+		if ($this->curl_connection) {
+			curl_close($this->curl_connection);
+		}
+	}
+
+	// are set as mandatory by the base searcher class but not used in this POC
+	public function loadValidFields() {}
+	public function loadDynamicFields() {}
+	public function getIndexError() {}
+	public function buildRSS($result = null) {}
+	public function buildExcel($result = null) {}
+	public function getResultRecordSet() {}
+	public function getSearchesFile() {}
+}

--- a/code/web/sys/SearchObject/BmjBpSearcher.php
+++ b/code/web/sys/SearchObject/BmjBpSearcher.php
@@ -19,6 +19,9 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 	/** @var int */
 	protected $limit = 10; // or use limit?
 
+	/** @var string */
+	private $jwt;
+
 	/** @var BmjBpSetting */
 	private $settings;
 
@@ -43,6 +46,30 @@ class SearchObject_BmjBpSearcher extends SearchObject_BaseSearcher{
 		}
 
 		return true;
+	}
+
+	public function getJwt(): string {
+		if (!$this->jwt) {
+			$this->setJwt($this->getSettings());
+		}
+		return $this->jwt;
+	}
+
+	public function setJwt(): void {
+		// TO BE REPLACED WITH THE USE OF A JWT LIBRARY
+		$header = [
+			"alg" => "HS256",
+			"typ" => "JWT"
+		];
+		$header = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(json_encode($header)));
+		$payload =  [
+			"iss" => $this->getSettings()->bmjBpApiKey,
+		];
+		$payload = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(json_encode($payload)));
+		$signature = str_replace(['+', '/', '='], ['-', '_', ''], base64_encode(hash_hmac('sha256', "$header.$payload", $this->getSettings()->bmjBpApiSecret, true)));
+		$this->jwt = "$header.$payload.$signature";
+		return;
+		// TO BE REPLACED WITH THE USE OF A JWT LIBRARY
 	}
 
 	public function getSettings(): BmjBpSetting {


### PR DESCRIPTION
## Description

An MVP for the BMJ integration, intended for YorCat only (for the time being), and which allows for the following:

Public

- Patrons are able to search for BMJ Best Practice records using the Aspen Discovery Search bar by setting to search ‘in BMJ Best Practice’.
- Patrons can view these search results and should only see, for each, the title of the article, as well as the first two lines of the article abstract.
- Patrons can click on the article’s title to be re-directed to the BMJ Best Practice website where they will be presented with the content or information on how to gain access to the content, as appropriate.
- In combined search results, patrons will see a ‘BMJ Best Practice’ search result section containing BMJ BP search results.

Staff

- Administrators with the right permissions can enable and disable the BMJ Best Practice module.
- Administrators with the right permissions can set the permissions to view, create, and edit BMJ Best Practice Settings.
- Administrators with the right permissions can view, create, and edit BMJ Best Practice Settings. These will be assigned system-wide.


## Test plan

1. In Aspen Administration > Primary Configuration > Modules, enable BMJ Best Practice.
2. In Aspen Administration > BMJ Best Practice > Settings, create a new setting, add the required credentials, assign it to the relevant libraries, and save.
3. Run a search in 'Articles and Databases', and notice that results are displayed. These should only have a title and a description.
4. Click on the title of one of the results, and notice that a new tab open and you are redirected to the relevant resource on the BMJ BP platform.
5. Run a search in 'Combined Results' and notice there is a BMJ Best Practice section populated with BMJ Best Practice search results.

## Note

This MVP is only intended for YorCat to test and will not be push upstream in its current state.