### PR TITLE
DIS-544: Add space after AU tag for RIS citations

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -3661,7 +3661,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 
 			if (!empty($authors)) {
 				foreach ($authors as $author){
-					$risFields[] = "AU - " . $author;
+					$risFields[] = "AU  - " . $author;
 				}
 			}
 


### PR DESCRIPTION
EndNote cannot proccess the AU field without the extra space.