### PR TITLE
Dis 913 docker arm builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract GitHub Tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         id: extract_tag
@@ -49,6 +55,7 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             aspendiscovery/aspen:latest
@@ -64,6 +71,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract GitHub Tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -104,6 +117,7 @@ jobs:
         with:
           context: .
           file: docker/files/solr/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             aspendiscovery/solr:latest
@@ -119,6 +133,12 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract GitHub Tag
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -159,6 +179,7 @@ jobs:
         with:
           context: .
           file: docker/files/tunnel/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             aspendiscovery/tunnel:latest

--- a/code/web/release_notes/25.06.00.MD
+++ b/code/web/release_notes/25.06.00.MD
@@ -251,6 +251,8 @@
 // chloe
 
 // jacob
+### Other Updates
+- Added ARM builds for docker images to github-actions (DIS-913) (*JOM*)
 
 // nick
 ### Other Updates


### PR DESCRIPTION
This patch adds arm builds to the github actions for docker. The only way to test this is with an arm machine. I have added a mirrored github action to this branch https://github.com/Jacobomara901/aspen-discovery/tree/test-arm-docker that publishes an arm image to my personal docker registry. You can amend the docker compose of ADB to use this image.
[@PerplexedTheta](https://github.com/PerplexedTheta) will probably have to test