### PR TITLE
DIS-1019: Add toast notifications to Community Engagement campaign milestones progress

### DIFF
--- a/code/web/interface/themes/responsive/css-rtl/responsive_base.less
+++ b/code/web/interface/themes/responsive/css-rtl/responsive_base.less
@@ -349,5 +349,6 @@ div.striped {
 @import "genealogy.less";
 @import "admin.less";
 @import "web-builder.less";
+@import "toast-notifications.less";
 @import "ebsco.less";
 @import "rtl-overrides.less";

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -11352,6 +11352,62 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
 .webResourceRow {
   margin-bottom: 4px;
 }
+.toast-notification {
+  display: flex;
+  align-items: center;
+  background-color: #1b6ec2;
+  color: #fff;
+  padding: 10px 20px 10px 0px;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  width: 400px;
+  position: fixed;
+}
+.toast-notification .toast-column-left {
+  flex: 0 0 20%;
+  display: flex;
+  justify-content: center;
+}
+.toast-notification .toast-column-right {
+  float: left;
+  width: 80%;
+  position: relative;
+}
+.toast-notification .toast-notification-icon {
+  font-size: 2.5em;
+}
+.toast-notification .toast-message-title {
+  font-size: 1.2em;
+  font-weight: bold;
+  margin-bottom: 5px;
+}
+.toast-notification .toast-message-subtitle {
+  font-size: 1em;
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 5px;
+}
+.toast-notification .toast-message-link {
+  text-decoration: underline;
+  color: white;
+}
+.toast-notification .toast-close {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin-top: -5px;
+  margin-right: -10px;
+  background-color: transparent;
+  border: none;
+  font-size: 1.5em;
+  cursor: pointer;
+  color: #fff;
+}
 .researchStarter {
   border: solid 1px #00a4e3;
   margin: 10px 5px 15px;

--- a/code/web/interface/themes/responsive/css/responsive_base.less
+++ b/code/web/interface/themes/responsive/css/responsive_base.less
@@ -421,6 +421,7 @@ div.striped {
 @import "genealogy.less";
 @import "admin.less";
 @import "web-builder.less";
+@import "toast-notifications.less";
 @import "ebsco.less";
 @import "cookie-consent.less";
 @import "talpa.less";

--- a/code/web/interface/themes/responsive/css/toast-notifications.less
+++ b/code/web/interface/themes/responsive/css/toast-notifications.less
@@ -1,0 +1,64 @@
+.toast-notification {
+  display: flex;
+  align-items: center;
+  background-color: #1b6ec2;
+  color: #fff;
+  padding: 10px 20px 10px 0px;
+  border-radius: 5px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  width: 400px;
+  position: fixed;
+
+  .toast-column-left {
+    flex: 0 0 20%;
+    display: flex;
+    justify-content: center;
+  }
+
+  .toast-column-right {
+    float: left;
+    width: 80%;
+    position: relative;
+  }
+
+  .toast-notification-icon {
+    font-size: 2.5em;
+  }
+
+  .toast-message-title {
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-bottom:5px;
+  }
+
+  .toast-message-subtitle {
+    font-size: 1em;
+    font-weight: bold;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-bottom:5px;
+  }
+
+  .toast-message-link {
+    text-decoration: underline;
+    color:white;
+  }
+
+  .toast-close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin-top: -5px;
+    margin-right: -10px;
+    background-color: transparent;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+    color: #fff;
+  }
+}
+

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5622,6 +5622,126 @@ jQuery.validator.addMethod("strongPassword", function(value, element) {
 
 	return '<ul class="password-error-list" style="margin-top:5px; margin-bottom:0; padding-left:1.25em; list-style-type:disc"><li>' + errors.join('</li><li>') + '</li></ul>';
 });
+AspenDiscovery.ToastNotifications = function() {
+	const debug = false; // Set to true to enable debug mode. true for dev only.
+	return {
+
+		/**
+		 * Listen to SSE (Server sent events)
+		 *
+		 * @param {String} args.eventSource
+		 * @param {String} args.eventName
+		 * @returns {boolean}
+		 */
+
+		listenToSSE: function(args) {
+			const eventSource = new EventSource(args.eventSource);
+
+			const closeEventSource = () => {
+				eventSource.close();
+			};
+			window.addEventListener('beforeunload', closeEventSource);
+
+			eventSource.addEventListener(args.eventName, e => {
+				const toastDataArray = JSON.parse(sessionStorage.getItem('toastDataArray')) || [];
+				const notificationAlreadyShown = toastDataArray.some(notification => notification.id === JSON.parse(e.data).id && notification.type === JSON.parse(e.data).type);
+				if (!notificationAlreadyShown || debug) {
+					toastDataArray.push(JSON.parse(e.data));
+					sessionStorage.setItem('toastDataArray', JSON.stringify(toastDataArray));
+					AspenDiscovery.ToastNotifications.showToast(JSON.parse(e.data));
+				}
+			})
+
+			eventSource.onclose = () => {
+				window.removeEventListener('beforeunload', closeEventSource);
+			};
+		},
+
+		/**
+		 * Show the toast notification
+		 *
+		 * Parameter SSEData must adhere to the following structure:
+		 * 
+		 * {
+		 *      id:    'my html id',
+		 *      title: 'toast title',
+		 *      body:  'toast body',
+		 *      link:  { href: 'url', text: 'link text' },
+		 *      icon:  'fa-icon'
+		 * }
+		 * 
+		 * @param {Object} SSEData
+		 */
+
+		showToast: function(SSEData) {
+			const toast = document.createElement('div');
+			toast.id = SSEData.id;
+			toast.className = 'toast-notification';
+			toast.innerHTML = `
+				<div class="toast-column-left">
+					<i class="fas ${SSEData.icon} toast-notification-icon"></i>
+				</div>
+				<div class="toast-column-right">
+					<p class="toast-message-title">${SSEData.title}</p>
+					<p class="toast-message-subtitle">${SSEData.body}</p>
+					${SSEData.link ? `<a class="toast-message-link" href="${SSEData.link.href}">${SSEData.link.text}</a>` : ''}
+					<button class="toast-close">×</button>
+				</div>
+			`;
+			const margin_spacing = 8;
+			const toast_height = 95;
+
+			let toast_bottom = margin_spacing;
+			
+			let adjustPosition = false;
+			if ($(document).find('.toast-notification').length == 3) {
+				$('.toast-notification').first().remove();
+				toast_bottom = (toast_height * 2) + (margin_spacing * 3);
+				adjustPosition = true;
+			}else if ($(document).find('.toast-notification').length == 1) {
+				toast_bottom = toast_height + (margin_spacing * 2);
+			}else if ($(document).find('.toast-notification').length == 2) {
+				toast_bottom = (toast_height * 2) + (margin_spacing * 3);
+			}
+
+			if( adjustPosition ){
+				let firstToast = $('.toast-notification').first()[0];
+				if(firstToast.style){
+					firstToast.style.bottom = parseInt(firstToast.style.bottom) - (toast_height + (margin_spacing)) + 'px';
+				}
+				let secondToast = $('.toast-notification').eq(1)[0];
+				if(secondToast.style){
+					secondToast.style.bottom = parseInt(secondToast.style.bottom) - (toast_height + (margin_spacing)) + 'px';
+				}
+			}
+
+			Object.assign(toast.style, {
+				bottom: toast_bottom + 'px',
+				right: margin_spacing+'px',
+				height: toast_height + 'px'
+			});
+			document.body.appendChild(toast);
+			const closeButton = toast.querySelector('.toast-close');
+			closeButton.addEventListener('click', () => {
+				toast.style.opacity = 0;
+				setTimeout(() => {
+				toast.remove();
+				}, 300);
+			});
+			setTimeout(() => {
+				toast.style.opacity = 1;
+			}, 10);
+			setTimeout(() => {
+				toast.style.opacity = 0;
+				setTimeout(() => {
+				toast.remove();
+				}, 300);
+			}, 9000);
+		},
+	}
+	
+}(AspenDiscovery.ToastNotifications || {});
+
 AspenDiscovery.Account = (function () {
 
 	// noinspection JSUnusedGlobalSymbols

--- a/code/web/interface/themes/responsive/js/aspen/toast-notifications.js
+++ b/code/web/interface/themes/responsive/js/aspen/toast-notifications.js
@@ -1,0 +1,119 @@
+AspenDiscovery.ToastNotifications = function() {
+	const debug = false; // Set to true to enable debug mode. true for dev only.
+	return {
+
+		/**
+		 * Listen to SSE (Server sent events)
+		 *
+		 * @param {String} args.eventSource
+		 * @param {String} args.eventName
+		 * @returns {boolean}
+		 */
+
+		listenToSSE: function(args) {
+			const eventSource = new EventSource(args.eventSource);
+
+			const closeEventSource = () => {
+				eventSource.close();
+			};
+			window.addEventListener('beforeunload', closeEventSource);
+
+			eventSource.addEventListener(args.eventName, e => {
+				const toastDataArray = JSON.parse(sessionStorage.getItem('toastDataArray')) || [];
+				const notificationAlreadyShown = toastDataArray.some(notification => notification.id === JSON.parse(e.data).id && notification.type === JSON.parse(e.data).type);
+				if (!notificationAlreadyShown || debug) {
+					toastDataArray.push(JSON.parse(e.data));
+					sessionStorage.setItem('toastDataArray', JSON.stringify(toastDataArray));
+					AspenDiscovery.ToastNotifications.showToast(JSON.parse(e.data));
+				}
+			})
+
+			eventSource.onclose = () => {
+				window.removeEventListener('beforeunload', closeEventSource);
+			};
+		},
+
+		/**
+		 * Show the toast notification
+		 *
+		 * Parameter SSEData must adhere to the following structure:
+		 * 
+		 * {
+		 *      id:    'my html id',
+		 *      title: 'toast title',
+		 *      body:  'toast body',
+		 *      link:  { href: 'url', text: 'link text' },
+		 *      icon:  'fa-icon'
+		 * }
+		 * 
+		 * @param {Object} SSEData
+		 */
+
+		showToast: function(SSEData) {
+			const toast = document.createElement('div');
+			toast.id = SSEData.id;
+			toast.className = 'toast-notification';
+			toast.innerHTML = `
+				<div class="toast-column-left">
+					<i class="fas ${SSEData.icon} toast-notification-icon"></i>
+				</div>
+				<div class="toast-column-right">
+					<p class="toast-message-title">${SSEData.title}</p>
+					<p class="toast-message-subtitle">${SSEData.body}</p>
+					${SSEData.link ? `<a class="toast-message-link" href="${SSEData.link.href}">${SSEData.link.text}</a>` : ''}
+					<button class="toast-close">×</button>
+				</div>
+			`;
+			const margin_spacing = 8;
+			const toast_height = 95;
+
+			let toast_bottom = margin_spacing;
+			
+			let adjustPosition = false;
+			if ($(document).find('.toast-notification').length == 3) {
+				$('.toast-notification').first().remove();
+				toast_bottom = (toast_height * 2) + (margin_spacing * 3);
+				adjustPosition = true;
+			}else if ($(document).find('.toast-notification').length == 1) {
+				toast_bottom = toast_height + (margin_spacing * 2);
+			}else if ($(document).find('.toast-notification').length == 2) {
+				toast_bottom = (toast_height * 2) + (margin_spacing * 3);
+			}
+
+			if( adjustPosition ){
+				let firstToast = $('.toast-notification').first()[0];
+				if(firstToast.style){
+					firstToast.style.bottom = parseInt(firstToast.style.bottom) - (toast_height + (margin_spacing)) + 'px';
+				}
+				let secondToast = $('.toast-notification').eq(1)[0];
+				if(secondToast.style){
+					secondToast.style.bottom = parseInt(secondToast.style.bottom) - (toast_height + (margin_spacing)) + 'px';
+				}
+			}
+
+			Object.assign(toast.style, {
+				bottom: toast_bottom + 'px',
+				right: margin_spacing+'px',
+				height: toast_height + 'px'
+			});
+			document.body.appendChild(toast);
+			const closeButton = toast.querySelector('.toast-close');
+			closeButton.addEventListener('click', () => {
+				toast.style.opacity = 0;
+				setTimeout(() => {
+				toast.remove();
+				}, 300);
+			});
+			setTimeout(() => {
+				toast.style.opacity = 1;
+			}, 10);
+			setTimeout(() => {
+				toast.style.opacity = 0;
+				setTimeout(() => {
+				toast.remove();
+				}, 300);
+			}, 9000);
+		},
+	}
+	
+}(AspenDiscovery.ToastNotifications || {});

--- a/code/web/interface/themes/responsive/js/javascript_files.txt
+++ b/code/web/interface/themes/responsive/js/javascript_files.txt
@@ -25,6 +25,7 @@ lib/swiper-bundle.min.js
 lib/tabs-manual.js
 aspen/globals.js
 aspen/base.js
+aspen/toast-notifications.js
 aspen/account.js
 aspen/admin.js
 aspen/authors.js

--- a/code/web/interface/themes/responsive/layout.tpl
+++ b/code/web/interface/themes/responsive/layout.tpl
@@ -179,6 +179,8 @@
 
 	{include file="tracking.tpl"}
 
+	{include file="sse.tpl"}
+
 	{if !empty($semanticData)}
 		{include file="jsonld.tpl"}
 	{/if}

--- a/code/web/interface/themes/responsive/sse.tpl
+++ b/code/web/interface/themes/responsive/sse.tpl
@@ -1,0 +1,12 @@
+{if !empty($loggedIn)}
+	{if array_key_exists('Community Engagement', $enabledModules)}
+		<script type="text/javascript">
+			AspenDiscovery.ToastNotifications.listenToSSE(
+				{
+					eventSource: '/MyAccount/AJAX?method=CommunityEngagementSSE',
+					eventName: 'ce_notification',
+				}
+			);
+		</script>
+	{/if}
+{/if}

--- a/code/web/release_notes/25.08.00.MD
+++ b/code/web/release_notes/25.08.00.MD
@@ -30,6 +30,10 @@
 
 // jacob
 
+// pedro
+### Community Engagement
+- Added toast notifications to Community Engagement campaign milestones progress (DIS-1019) (*PA*)
+
 // nick
 
 // lucas
@@ -67,6 +71,7 @@
 - Alexander Blanchard (AB)
 - Chloe Zermatten (CZ)
 - Jacob O'Mara (JOM)
+- Pedro Amorim (PA)
 
 ### Theke Solutions
 - Lucas Montoya (LM)

--- a/code/web/services/CommunityEngagement/AJAX.php
+++ b/code/web/services/CommunityEngagement/AJAX.php
@@ -311,10 +311,8 @@ class CommunityEngagement_AJAX extends JSON_Action {
 	}
 
 	public function manuallyProgressUserMilestone() {
-		require_once ROOT_DIR . '/sys/CommunityEngagement/Campaign.php';
-		require_once ROOT_DIR . '/sys/CommunityEngagement/Milestone.php';
 		require_once ROOT_DIR . '/sys/CommunityEngagement/UserCampaign.php';
-		require_once ROOT_DIR . '/sys/CommunityEngagement/CampaignMilestoneUsersProgress.php';
+		require_once ROOT_DIR . '/sys/CommunityEngagement/CampaignMilestone.php';
 
 		$milestoneId = $_GET['milestoneId'] ?? null;
 		$userId = $_GET['userId'] ?? null;
@@ -365,20 +363,10 @@ class CommunityEngagement_AJAX extends JSON_Action {
 			exit;
 		}
 
-
-		$campaignMilestoneUsersProgress = new CampaignMilestoneUsersProgress();
-		$campaignMilestoneUsersProgress->ce_milestone_id = $milestoneId;
-		$campaignMilestoneUsersProgress->userId = $userId;
-		$campaignMilestoneUsersProgress->ce_campaign_id = $campaignId;
-
-
-		if ($campaignMilestoneUsersProgress->find(true)) {
-			$campaignMilestoneUsersProgress->progress++;
-			$campaignMilestoneUsersProgress->update();
-		} else {
-			$campaignMilestoneUsersProgress->progress++;
-			$campaignMilestoneUsersProgress->insert();
-		}
+		$campaignMilestone = new CampaignMilestone();
+		$campaignMilestone->campaignId = $campaignId;
+		$campaignMilestone->milestoneId = $milestoneId;
+		$campaignMilestone->addCampaignMilestoneProgressEntry(null, $userId, null);
 
 		$userCampaign = new UserCampaign();
 		$userCampaign->userId = $userId;

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -10055,6 +10055,12 @@ class MyAccount_AJAX extends JSON_Action {
 						$userCampaign->campaignId = $campaignMilestoneProgressEntry->ce_campaign_id;
 						$userCampaign->find(true);
 
+						$unwantedOverflowProgress = $campaignMilestoneUsersProgress->progress > $campaignMilestone->goal &&  !$milestone->progressBeyondOneHundredPercent;
+						$wantedOverflowProgress = $campaignMilestoneUsersProgress->progress > $campaignMilestone->goal &&  $milestone->progressBeyondOneHundredPercent;
+						if( $unwantedOverflowProgress ){
+							exit();
+						}
+
 						# Handle milestone progress notification
 						echo "event: ce_notification\n";
 						echo "data: " . json_encode(
@@ -10078,7 +10084,7 @@ class MyAccount_AJAX extends JSON_Action {
 						) . "\n\n";
 
 						# Handle milestone completion notification
-						if ($campaignMilestoneUsersProgress->progress >= $campaignMilestone->goal ) {
+						if ($campaignMilestoneUsersProgress->progress >= $campaignMilestone->goal && !$wantedOverflowProgress) {
 							echo "event: ce_notification\n";
 							echo "data: " . json_encode(
 								array(
@@ -10102,7 +10108,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 
 						# Handle campaign completion notification
-						if ($userCampaign->completed) {
+						if ($userCampaign->completed && !$wantedOverflowProgress) {
 							echo "event: ce_notification\n";
 							echo "data: " . json_encode(
 								array(

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -9986,6 +9986,160 @@ class MyAccount_AJAX extends JSON_Action {
 		}
 	}
 
+	/**
+	 * Sends server-sent events (SSE) notifications about community engagement milestones and campaigns.
+	 */
+
+	public function CommunityEngagementSSE() {
+		$debug = false; // Set to true to enable debug mode. true for dev only.
+		if (UserAccount::isLoggedIn()) {
+
+			$patron = UserAccount::getActiveUserObj();
+
+			require_once ROOT_DIR . '/sys/CommunityEngagement/CampaignMilestoneProgressEntry.php';
+			require_once ROOT_DIR . '/sys/CommunityEngagement/CampaignMilestoneUsersProgress.php';
+			require_once ROOT_DIR . '/sys/CommunityEngagement/CampaignMilestone.php';
+			require_once ROOT_DIR . '/sys/CommunityEngagement/Campaign.php';
+			require_once ROOT_DIR . '/sys/CommunityEngagement/Milestone.php';
+			require_once ROOT_DIR . '/sys/CommunityEngagement/UserCampaign.php';
+
+			header("X-Accel-Buffering: no");
+			header("Content-Type: text/event-stream");
+			header("Cache-Control: no-cache");
+
+			echo "event: established\n";
+			echo "data: connection established\n\n";
+
+			ob_end_flush();
+
+			$interval = 10;
+
+			while (true) {
+
+				if( $debug ){
+					global $logger;
+					$logger->log("RUNNING SSE ", Logger::LOG_ERROR);
+				}
+				// Break the loop if the client aborted the connection (closed the page)
+				if (connection_status() != CONNECTION_NORMAL || connection_aborted()) exit();
+
+				$campaignMilestoneProgressEntry = new CampaignMilestoneProgressEntry();
+				$campaignMilestoneProgressEntry->userId = $patron->id;
+				if(!$debug){
+					$campaignMilestoneProgressEntry->whereAdd("timestamp >= DATE_SUB(NOW(), INTERVAL " . $interval . " SECOND)");
+				}
+
+				if ($campaignMilestoneProgressEntry->find()) {
+					while ($campaignMilestoneProgressEntry->fetch()) {
+
+						# Prepare data
+						$campaign = new Campaign();
+						$campaign->id = $campaignMilestoneProgressEntry->ce_campaign_id;
+						$campaign->find(true);
+
+						$milestone = new Milestone();
+						$milestone->id = $campaignMilestoneProgressEntry->ce_milestone_id;
+						$milestone->find(true);
+
+						$campaignMilestoneUsersProgress = new CampaignMilestoneUsersProgress();
+						$campaignMilestoneUsersProgress->id = $campaignMilestoneProgressEntry->ce_campaign_milestone_users_progress_id;
+						$campaignMilestoneUsersProgress->find(true);
+
+						$campaignMilestone = new CampaignMilestone();
+						$campaignMilestone->campaignId = $campaignMilestoneProgressEntry->ce_campaign_id;
+						$campaignMilestone->milestoneId = $campaignMilestoneProgressEntry->ce_milestone_id;
+						$campaignMilestone->find(true);
+
+						$userCampaign = new UserCampaign();
+						$userCampaign->userId = $patron->id;
+						$userCampaign->campaignId = $campaignMilestoneProgressEntry->ce_campaign_id;
+						$userCampaign->find(true);
+
+						# Handle milestone progress notification
+						echo "event: ce_notification\n";
+						echo "data: " . json_encode(
+							array(
+								'id'=> $campaignMilestoneProgressEntry->id . '_ce_milestone_progress',
+								'title'=> translate(
+										[
+											'text' => 'Milestone progress! Good job!',
+											'isPublicFacing' => true
+										]
+									),
+								'body' => $campaignMilestoneUsersProgress->progress.'/'.$campaignMilestone->goal.' ' .$milestone->name,
+								'icon' => "fa-chart-line",
+								'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
+										[
+											'text' => 'View all campaigns',
+											'isPublicFacing' => true
+										]
+									)]
+							)
+						) . "\n\n";
+
+						# Handle milestone completion notification
+						if ($campaignMilestoneUsersProgress->progress >= $campaignMilestone->goal ) {
+							echo "event: ce_notification\n";
+							echo "data: " . json_encode(
+								array(
+									'id'=> $campaignMilestoneProgressEntry->id . '_ce_milestone_completed',
+									'title'=> translate(
+										[
+											'text' => 'Milestone completed! Well done!',
+											'isPublicFacing' => true
+										]
+									),
+									'body' => $milestone->name,
+									'icon' => "fa-clipboard-check",
+									'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
+										[
+											'text' => 'View all campaigns',
+											'isPublicFacing' => true
+										]
+									)]
+								)
+							) . "\n\n";
+						}
+
+						# Handle campaign completion notification
+						if ($userCampaign->completed) {
+							echo "event: ce_notification\n";
+							echo "data: " . json_encode(
+								array(
+									'id'=> $campaignMilestoneProgressEntry->id . '_ce_campaign_completed',
+									'title'=> translate(
+										[
+											'text' => 'Campaign completed! Awesome!',
+											'isPublicFacing' => true
+										]
+									),
+									'body' => $campaign->name,
+									'icon' => "fa-medal",
+									'link' => ['href' => '/MyAccount/MyCampaigns', 'text' => translate(
+										[
+											'text' => 'View all campaigns',
+											'isPublicFacing' => true
+										]
+									)]
+								)
+							) . "\n\n";
+						}
+					}
+				}else{
+					echo "event: heart_beat\n";
+					echo "data: No notifications found\n\n";
+				}
+
+				if (ob_get_contents()) {
+					ob_end_flush();
+				}
+				flush();
+
+				sleep($interval);
+			}
+		}
+	}
+
 	function getYearInReviewSlide() : array {
 		$result = [
 			'success' => false,

--- a/code/web/sys/CommunityEngagement/CampaignMilestone.php
+++ b/code/web/sys/CommunityEngagement/CampaignMilestone.php
@@ -234,16 +234,8 @@ class CampaignMilestone extends DataObject {
 		$campaignMilestoneUsersProgress->ce_campaign_id = $this->campaignId;
 		$campaignMilestoneUsersProgress->userId = $userId;
 
-        # There is one, bail if goal has already been met
-        if ($campaignMilestoneUsersProgress->find(true)) {
-            // if ($campaignMilestoneUsersProgress->progress >= $this->goal) {
-            //     $campaignMilestoneUsersProgress->extraProgress++;
-            //     $campaignMilestoneUsersProgress->update();
-            //     return;
-            // }
-            
-        # There isn't one, create it.
-        } else {
+		# Create campaign milestone if doesn't exist yet
+		if (!$campaignMilestoneUsersProgress->find(true)) {
             $campaignMilestoneUsersProgress->progress = 0;
             $campaignMilestoneUsersProgress->extraProgress = 0;
             $campaignMilestoneUsersProgress->insert();

--- a/code/web/sys/CommunityEngagement/CampaignMilestoneProgressEntry.php
+++ b/code/web/sys/CommunityEngagement/CampaignMilestoneProgressEntry.php
@@ -12,6 +12,7 @@ class CampaignMilestoneProgressEntry extends DataObject
 	public $tableName;
 	public $processed;
 	public $object;
+	public $timestamp;
 
 	/**
 	 * Initializes a new CampaignMilestoneProgressEntry object by setting its ce_milestone_id to the provided milestone object

--- a/code/web/sys/CommunityEngagement/CampaignMilestoneProgressEntry.php
+++ b/code/web/sys/CommunityEngagement/CampaignMilestoneProgressEntry.php
@@ -40,8 +40,10 @@ class CampaignMilestoneProgressEntry extends DataObject
 		$this->userId = $args['userId'];
 		$this->ce_campaign_milestone_users_progress_id = $args['campaignMilestoneUsersProgress']->id;
 		$this->processed = 0;
-		$this->tableName = $args['object']->__table;
-		$this->object = json_encode($args['object']);
+		if($args['object']){
+			$this->tableName = $args['object']->__table;
+			$this->object = json_encode($args['object']);
+		}
 		$this->insert();
 	}
 

--- a/code/web/sys/DBMaintenance/version_updates/25.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/25.08.00.php
@@ -35,6 +35,16 @@ function getUpdates25_08_00(): array {
 
 		//Jacob - Open Fifth
 
+		//Pedro - Open Fifth
+		'add_timestamp_to_ce_campaign_milestone_progress_entries' => [
+			'title' => 'Update ce_campaign_milestone_progress_entries',
+			'description' => 'Add timestamp to ce_campaign_milestone_progress_entries',
+			'sql' => [
+				"ALTER TABLE ce_campaign_milestone_progress_entries ADD COLUMN `timestamp` datetime NOT NULL DEFAULT (CURRENT_TIME)",
+			],
+		], //add_timestamp_to_ce_campaign_milestone_progress_entries
+
+
 		//James Staub - Nashville Public Library
 
 		//Lucas Montoya - Theke Solutions

--- a/install/aspen.sql
+++ b/install/aspen.sql
@@ -823,6 +823,7 @@ CREATE TABLE `ce_campaign_milestone_progress_entries` (
   `tableName` varchar(100) DEFAULT NULL,
   `processed` tinyint(4) DEFAULT 0,
   `object` mediumtext DEFAULT NULL,
+  `timestamp` datetime NOT NULL DEFAULT current_timestamp(),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 DROP TABLE IF EXISTS ce_campaign_milestone_users_progress;


### PR DESCRIPTION
Test plan, using adb with ktd:

Enable Community Engagement module.
Create a reward. Create a milestone of type 'Rating'. Create a campaign that starts at a past date and ends at a future date. Available for all libraries and all patron categories. Add the previously created milestone to this campaign with a goal e.g. 10.
Masquerade as a real patron, I've used '23529000035676' on my testing (Henry Acevedo).
On the user menu, click 'Your campaigns' and enroll on the campaign created in 2)
Do a search e.g. 'music' and on the search results, pick one and click 'Add a review'. Submit the review with some rating and any text.
Notice a toast notification displaying a milestone progress message is shown. You may have to wait up to 10 seconds for this notification to show as that is the SSE heartbeat frequency. If you move to any other URL before the notification is shown, it'll display instantly (because it restarts the SSE connection on a new page visit).
The above is the baseline testing of the functionality. Additional testing:

Create other types of milestone types (checkouts, holds)
Create a manual milestone. Verify that the toast notifications show for manual progress
Complete a milestone. Verify that a 'Milestone completed' toast notification is shown.
Complete a campaign. Verify that a 'Campaign completed' toast notification is shown.
Create a milestone that allows progress beyond 100%. Verify the 'milestone progress' toast notification is also shown for every progress made beyond 100%.
Continuing from 3. Verify that the 'Campaign completed' is only shown when the campaign is completed, and not for every milestone progress beyond 100%.